### PR TITLE
Added cog-marketo unit tests

### DIFF
--- a/test/steps/lead-create-or-update.ts
+++ b/test/steps/lead-create-or-update.ts
@@ -1,0 +1,114 @@
+import { Struct } from 'google-protobuf/google/protobuf/struct_pb';
+import * as chai from 'chai';
+import { default as sinon } from 'ts-sinon';
+import * as sinonChai from 'sinon-chai';
+import 'mocha';
+
+import { Step as ProtoStep, StepDefinition, RunStepResponse } from '../../src/proto/cog_pb';
+import { Step } from '../../src/steps/lead-create-or-update';
+
+chai.use(sinonChai);
+
+describe('CreateOrUpdateLeadByFieldStep', () => {
+  const expect = chai.expect;
+  let protoStep: ProtoStep;
+  let stepUnderTest: Step;
+  let clientWrapperStub: any;
+
+  beforeEach(() => {
+    protoStep = new ProtoStep();
+    clientWrapperStub = sinon.stub();
+    clientWrapperStub.createOrUpdateLead = sinon.stub();
+    stepUnderTest = new Step(clientWrapperStub);
+  });
+
+  it('should return expected step metadata', () => {
+    const stepDef: StepDefinition = stepUnderTest.getDefinition();
+    expect(stepDef.getStepId()).to.equal('CreateOrUpdateLeadByFieldStep');
+    expect(stepDef.getName()).to.equal('Create or update a Marketo Lead');
+    expect(stepDef.getExpression()).to.equal('create or update a marketo lead');
+    expect(stepDef.getType()).to.equal(StepDefinition.Type.ACTION);
+  });
+
+  it('should call the client wrapper with the expected args', async () => {
+    protoStep.setData(Struct.fromJavaScript({
+      email: 'sampleEmail@example.com',
+    }));
+
+    await stepUnderTest.executeStep(protoStep);
+    expect(clientWrapperStub.createOrUpdateLead).to.have.been.calledWith(
+      protoStep.getData().toJavaScript().lead,
+    );
+  });
+
+  it('should respond with success if the marketo executes succesfully', async () => {
+    const expectedEmail: string = 'expected@example.com';
+    const expectedReason: string = 'reason it failed';
+    clientWrapperStub.createOrUpdateLead.returns(Promise.resolve({
+      success: true,
+      result: [
+        {
+          status: 'success',
+        },
+      ],
+    }));
+    protoStep.setData(Struct.fromJavaScript({
+      lead: {
+        email: 'sampleEmail@example.com',
+      },
+    }));
+    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+  });
+
+  it('should respond with fail if the marketo skips creation of lead with reason', async () => {
+    const expectedReason: string = 'reason it failed';
+    clientWrapperStub.createOrUpdateLead.returns(Promise.resolve({
+      success: true,
+      result: [
+        {
+          status: 'skipped',
+          reasons: [
+            {
+              message: expectedReason,
+            },
+          ],
+        },
+      ],
+    }));
+    protoStep.setData(Struct.fromJavaScript({
+      email: 'sampleEmail@example.com',
+    }));
+    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.FAILED);
+    expect(response.getMessageArgsList()[0].getStringValue()).to.equal(expectedReason);
+  });
+
+  it('should respond with fail if the marketo skips creation of lead', async () => {
+    const expectedMessage: string  = 'status was skipped';
+    clientWrapperStub.createOrUpdateLead.returns(Promise.resolve({
+      success: true,
+      result: [
+        {
+          status: 'skipped',
+        },
+      ],
+    }));
+    protoStep.setData(Struct.fromJavaScript({
+      email: 'sampleEmail@example.com',
+    }));
+    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.FAILED);
+    expect(response.getMessageArgsList()[0].getStringValue()).to.equal(expectedMessage);
+  });
+
+  it('should respond with an error if the marketo throws an error', async () => {
+    clientWrapperStub.createOrUpdateLead.throws('any error');
+    protoStep.setData(Struct.fromJavaScript({
+      email: 'any@email.com',
+    }));
+    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
+  });
+
+});

--- a/test/steps/lead-delete.ts
+++ b/test/steps/lead-delete.ts
@@ -1,0 +1,116 @@
+import { Struct } from 'google-protobuf/google/protobuf/struct_pb';
+import * as chai from 'chai';
+import { default as sinon } from 'ts-sinon';
+import * as sinonChai from 'sinon-chai';
+import 'mocha';
+
+import { Step as ProtoStep, StepDefinition, RunStepResponse } from '../../src/proto/cog_pb';
+import { Step } from '../../src/steps/lead-delete';
+
+chai.use(sinonChai);
+
+describe('DeleteLeadStep', () => {
+  const expect = chai.expect;
+  let protoStep: ProtoStep;
+  let stepUnderTest: Step;
+  let clientWrapperStub: any;
+
+  beforeEach(() => {
+    protoStep = new ProtoStep();
+    clientWrapperStub = sinon.stub();
+    clientWrapperStub.findLeadByEmail = sinon.stub();
+    clientWrapperStub.deleteLeadById = sinon.stub();
+    stepUnderTest = new Step(clientWrapperStub);
+  });
+
+  it('should return expected step metadata', () => {
+    const stepDef: StepDefinition = stepUnderTest.getDefinition();
+    expect(stepDef.getStepId()).to.equal('DeleteLeadStep');
+    expect(stepDef.getName()).to.equal('Delete a Marketo Lead');
+    expect(stepDef.getExpression()).to.equal('delete the (?<email>.+) marketo lead');
+    expect(stepDef.getType()).to.equal(StepDefinition.Type.ACTION);
+  });
+
+  it('should respond with success if the marketo executes succesfully', async () => {
+    const expectedEmail: string = 'sampleEmail@email.com';
+    protoStep.setData(Struct.fromJavaScript({
+      email: expectedEmail,
+    }));
+    clientWrapperStub.findLeadByEmail.returns(Promise.resolve({
+      success: true,
+      result: [
+        {
+          id: '12345',
+        },
+      ],
+    }));
+    clientWrapperStub.deleteLeadById.returns(Promise.resolve({
+      success: true,
+      result: [
+        {
+          status: 'deleted',
+        },
+      ],
+    }));
+    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+    expect(response.getMessageArgsList()[0].getStringValue()).to.equal(expectedEmail);
+  });
+
+  it('should respond with error if the marketo unable to delete lead', async () => {
+    const expectedEmail: string = 'sampleEmail@email.com';
+    const expectedResponse: string = 'Unable to delete lead %s: %s';
+    protoStep.setData(Struct.fromJavaScript({
+      email: expectedEmail,
+    }));
+    clientWrapperStub.findLeadByEmail.returns(Promise.resolve({
+      success: true,
+      result: [
+        {
+          id: '12345',
+        },
+      ],
+    }));
+    clientWrapperStub.deleteLeadById.returns(Promise.resolve({
+      success: true,
+      result: [
+        {
+          status: 'failed',
+        },
+      ],
+    }));
+    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
+    expect(response.getMessageFormat()).to.equal(expectedResponse);
+    expect(response.getMessageArgsList()[0].getStringValue()).to.equal(expectedEmail);
+  });
+
+  it('should respond with error if the marketo could not find lead', async () => {
+    const expectedEmail: string = 'sampleEmail@email.com';
+    const expectedMessage: string = 'a lead with that email address does not exist.';
+    protoStep.setData(Struct.fromJavaScript({
+      email: expectedEmail,
+    }));
+    clientWrapperStub.findLeadByEmail.returns(Promise.resolve({
+      success: false,
+    }));
+    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
+    expect(response.getMessageArgsList()[0].getStringValue()).to.equal(expectedEmail);
+    expect(response.getMessageArgsList()[1].getStringValue()).to.equal(expectedMessage);
+  });
+
+  it('should respond with error if the marketo throws an error', async () => {
+    const expectedEmail: string = 'sampleEmail@email.com';
+    const expectedMessage: string = 'a lead with that email address does not exist.';
+    const expectedError: string = 'any error';
+    protoStep.setData(Struct.fromJavaScript({
+      email: expectedEmail,
+    }));
+    clientWrapperStub.findLeadByEmail.throws(expectedError);
+    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
+    expect(response.getMessageArgsList()[0].getStringValue()).to.equal(expectedEmail);
+    expect(response.getMessageArgsList()[1].getStringValue()).to.equal(expectedError);
+  });
+});


### PR DESCRIPTION
Added unit tests for steps:
- lead-or-create-lead
- lead-delete