### PR TITLE
Fixed steps from returning invalid pass/fail message because the oper…

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,6 @@
     "grpc": "^1.21.1",
     "node-marketo-rest": "^0.7.5",
     "ts-node": "^8.3.0",
-    "moment": "^2.18.1"
+    "moment": "^2.24.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "google-protobuf": "^3.8.0",
     "grpc": "^1.21.1",
     "node-marketo-rest": "^0.7.5",
-    "ts-node": "^8.3.0"
+    "ts-node": "^8.3.0",
+    "moment": "^2.18.1"
   }
 }

--- a/src/steps/lead-field-equals.ts
+++ b/src/steps/lead-field-equals.ts
@@ -44,9 +44,9 @@ export class LeadFieldEqualsStep extends BaseStep implements StepInterface {
 
       if (data.success && data.result && data.result[0] && data.result[0].hasOwnProperty(field)) {
         if (this.compare(operator, data.result[0][field], expectation)) {
-          return this.pass(this.operatorSuccessMessages[operator.replace(/\s/g, '').toLowerCase()], [field, expectation]);
+          return this.pass(this.operatorSuccessMessages[operator], [field, expectation]);
         } else {
-          return this.fail(this.operatorFailMessages[operator.replace(/\s/g, '').toLowerCase()], [
+          return this.fail(this.operatorFailMessages[operator], [
             field,
             expectation,
             data.result[0][field],


### PR DESCRIPTION
The `util` had a change in determining proper `pass/fail` messages as seen on:

https://github.com/run-crank/typescript-cog-utilities/blob/master/src/utils/compare.ts#L4

There are steps affected that still has the `.replace(/\s/g, '').toLowerCase()` code which removes all space and then therefore cannot be mapped to the updated pass fail messages in the `util` (which now contains space)