### PR TITLE
Default lead fields

### DIFF
--- a/src/client/mixins/lead-aware.ts
+++ b/src/client/mixins/lead-aware.ts
@@ -14,7 +14,6 @@ export class LeadAwareMixin {
     if (options) {
       options.fields = options.fields || [];
       options.fields = Array.from(new Set(options.fields.concat(DEFAULT_FIELDS))).join(','); //// Ensure unique fields
-      console.log(options.fields);
       return this.client.lead.find('email', [email], options);
     }
 

--- a/src/client/mixins/lead-aware.ts
+++ b/src/client/mixins/lead-aware.ts
@@ -1,4 +1,7 @@
 import * as Marketo from 'node-marketo-rest';
+
+const DEFAULT_FIELDS: string[] = ['email', 'createdAt', 'updatedAt', 'id', 'firstName', 'lastName'];
+
 export class LeadAwareMixin {
   client: Marketo;
   leadDescription: any;
@@ -7,9 +10,15 @@ export class LeadAwareMixin {
     return this.client.lead.createOrUpdate([lead], { lookupField: 'email' });
   }
 
-  public async findLeadByEmail(email: string) {
-    const fields = await this.describeLeadFields();
-    return this.client.lead.find('email', [email], { fields: fields.result.map(field => field.rest).map(rest => rest.name) });
+  public async findLeadByEmail(email: string, options: Record<string, any> = null) {
+    if (options) {
+      options.fields = options.fields || [];
+      options.fields = Array.from(new Set(options.fields.concat(DEFAULT_FIELDS))).join(','); //// Ensure unique fields
+      console.log(options.fields);
+      return this.client.lead.find('email', [email], options);
+    }
+
+    return this.client.lead.find('email', [email]);
   }
 
   public async deleteLeadById(leadId: number) {

--- a/src/steps/custom-object-create-or-update.ts
+++ b/src/steps/custom-object-create-or-update.ts
@@ -87,7 +87,7 @@ export class CreateOrUpdateCustomObjectStep extends BaseStep implements StepInte
 
       // Getting link field value from lead
       const lead = await this.client.findLeadByEmail(linkValue, {
-        fields: ['email', linkField].join(','),
+        fields: [linkField],
       });
 
       // Check if leads are retrieved

--- a/src/steps/custom-object-delete.ts
+++ b/src/steps/custom-object-delete.ts
@@ -67,7 +67,7 @@ export class DeleteCustomObjectStep extends BaseStep implements StepInterface {
 
       // Getting link field value from lead
       const lead = await this.client.findLeadByEmail(linkValue, {
-        fields: ['email', linkField].join(','),
+        fields: [linkField],
       });
 
       if (!lead.result.length) {

--- a/src/steps/lead-field-equals.ts
+++ b/src/steps/lead-field-equals.ts
@@ -68,7 +68,9 @@ export class LeadFieldEqualsStep extends BaseStep implements StepInterface {
     const field = stepData.field;
 
     try {
-      const data: any = await this.client.findLeadByEmail(email);
+      const data: any = await this.client.findLeadByEmail(email, {
+        fields: [field],
+      });
 
       if (data.success && data.result && data.result[0] && data.result[0].hasOwnProperty(field)) {
         if (this.compare(operator, data.result[0][field], expectation)) {

--- a/test/client/client-wrapper.ts
+++ b/test/client/client-wrapper.ts
@@ -6,6 +6,8 @@ import 'mocha';
 import { ClientWrapper } from '../../src/client/client-wrapper';
 import { Metadata } from 'grpc';
 
+const DEFAULT_FIELDS: string[] = ['email', 'createdAt', 'updatedAt', 'id', 'firstName', 'lastName'];
+
 chai.use(sinonChai);
 
 describe('ClientWrapper', () => {
@@ -97,13 +99,15 @@ describe('ClientWrapper', () => {
   it('findLeadByEmail (no options)', (done) => {
     const expectedEmail = 'test@example.com';
     clientWrapperUnderTest = new ClientWrapper(metadata, marketoConstructorStub);
-    clientWrapperUnderTest.findLeadByEmail(expectedEmail);
+    clientWrapperUnderTest.findLeadByEmail(expectedEmail, {
+      fields: ['middleName', 'age'],
+    });
 
     setTimeout(() => {
       expect(marketoClientStub.lead.find).to.have.been.calledWith(
         'email',
         [expectedEmail],
-        { fields: ['email'] },
+        { fields: ['middleName', 'age', ...DEFAULT_FIELDS].join(',') },
       );
       done();
     });
@@ -112,13 +116,15 @@ describe('ClientWrapper', () => {
   it('findLeadByEmail (with options)', (done) => {
     const expectedEmail = 'test@example.com';
     clientWrapperUnderTest = new ClientWrapper(metadata, marketoConstructorStub);
-    clientWrapperUnderTest.findLeadByEmail(expectedEmail);
+    clientWrapperUnderTest.findLeadByEmail(expectedEmail, {
+      fields: ['middleName', 'age'],
+    });
 
     setTimeout(() => {
       expect(marketoClientStub.lead.find).to.have.been.calledWith(
         'email',
         [expectedEmail],
-        { fields: ['email'] },
+        { fields: ['middleName', 'age', ...DEFAULT_FIELDS].join(',') },
       );
 
       done();


### PR DESCRIPTION
Previously, all lead fields are returned using an additional `lead.describe` call.
For now, created a list of `DEFAULT_FIELDS`: `['email', 'createdAt', 'updatedAt', 'id', 'firstName', 'lastName']`
