### PR TITLE
Added activity fields as validatable fields for the withAttributes pa…

### DIFF
--- a/src/steps/check-lead-activity.ts
+++ b/src/steps/check-lead-activity.ts
@@ -128,6 +128,16 @@ export class CheckLeadActivityStep extends BaseStep implements StepInterface {
         for (const activity of activities) {
           const primaryAttribute = this.getPrimaryAttribute(activityTypes, activity);
           const actualAttributes = activity.attributes;
+
+          Object.keys(activity).forEach((key) => {
+            if (key !== 'attributes') {
+              actualAttributes.push({
+                name: key,
+                value: activity[key],
+              });
+            }
+          });
+
           if (primaryAttribute) {
             actualAttributes.push(primaryAttribute);
           }


### PR DESCRIPTION
For #67 :

 - Now the step includes all basic properties of an `activity` e.g. `leadId` or `campaignId` as validatable fields.
 - To test, you may pass these key-values as part of the `withAttributes` parameter.