### PR TITLE
Lead retrieval sanity checking on request size

### DIFF
--- a/src/steps/lead-field-equals.ts
+++ b/src/steps/lead-field-equals.ts
@@ -68,7 +68,7 @@ export class LeadFieldEqualsStep extends BaseStep implements StepInterface {
     const field = stepData.field;
 
     try {
-      const data: any = await this.client.findLeadByEmail(email);
+      const data: any = await this.client.findLeadByEmail(email, field);
 
       if (data.success && data.result && data.result[0] && data.result[0].hasOwnProperty(field)) {
         if (this.compare(operator, data.result[0][field], expectation)) {


### PR DESCRIPTION
Note: this does not implement the `PUT` with `_method=GET` workaround to this issue mentioned [in Marketo's API docs](https://developers.marketo.com/rest-api/lead-database/leads/#query).  ...Because that workaround does not appear to actually work.

Instead, in cases where the request _would_ fail, we just return to the default, bare minimum field retrieval.

Closes #70 