### PR TITLE
Support "be one of" and "not be one of" operators

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -187,10 +187,11 @@
       }
     },
     "@run-crank/utilities": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@run-crank/utilities/-/utilities-0.2.1.tgz",
-      "integrity": "sha512-YppiOPxDL6XxVi/Sqip5AnDMOOHL9E5/8dyJg1hr2TqzvvOlpUugr5gDWZ9a0yHxmllsFXTLtw9Lx7PflvLqpg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@run-crank/utilities/-/utilities-0.3.0.tgz",
+      "integrity": "sha512-ZG/gSv4OLzC99du5D1gXEF6j3lGp/MrwPrk9cfRY+RGJJcLzT6V34PKLNgQI4z7QG3VnFxUyr6RRXv6VDqjtwg==",
       "requires": {
+        "csv-string": "^4.0.1",
         "moment": "^2.24.0"
       }
     },
@@ -1200,6 +1201,11 @@
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
       }
+    },
+    "csv-string": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/csv-string/-/csv-string-4.0.1.tgz",
+      "integrity": "sha512-nCdK+EWDbqLvZ2MmVQhHTmidMEsHbK3ncgTJb4oguNRpkmH5OOr+KkDRB4nqsVrJ7oK0AdO1QEsBp0+z7KBtGQ=="
     },
     "date.js": {
       "version": "0.3.3",
@@ -4709,7 +4715,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "typescript": "^3.5.1"
   },
   "dependencies": {
-    "@run-crank/utilities": "^0.2.1",
+    "@run-crank/utilities": "^0.3.0",
     "google-protobuf": "^3.8.0",
     "grpc": "^1.24.3",
     "moment": "^2.24.0",

--- a/src/steps/custom-object-field-equals.ts
+++ b/src/steps/custom-object-field-equals.ts
@@ -7,7 +7,7 @@ import { Step, FieldDefinition, StepDefinition, RecordDefinition } from '../prot
 export class CustomObjectFieldEqualsStep extends BaseStep implements StepInterface {
 
   protected stepName: string = 'Check a field on a Marketo Custom Object';
-  protected stepExpression: string = 'the (?<field>[a-zA-Z0-9_-]+) field on the (?<name>.+) marketo custom object linked to lead (?<linkValue>.+) should (?<operator>be set|not be set|be less than|be greater than|be|contain|not be|not contain) ?(?<expectedValue>.+)?';
+  protected stepExpression: string = 'the (?<field>[a-zA-Z0-9_-]+) field on the (?<name>.+) marketo custom object linked to lead (?<linkValue>.+) should (?<operator>be set|not be set|be less than|be greater than|be one of|be|contain|not be one of|not be|not contain) ?(?<expectedValue>.+)?';
   protected stepType: StepDefinition.Type = StepDefinition.Type.VALIDATION;
   protected expectedFields: Field[] = [{
     field: 'name',
@@ -24,7 +24,7 @@ export class CustomObjectFieldEqualsStep extends BaseStep implements StepInterfa
   }, {
     field: 'operator',
     type: FieldDefinition.Type.STRING,
-    description: 'Check Logic (be, not be, contain, not contain, be greater than, be less than, be set, or not be set)',
+    description: 'Check Logic (be, not be, contain, not contain, be greater than, be less than, be set, not be set, be one of, or not be one of)',
   }, {
     field: 'expectedValue',
     type: FieldDefinition.Type.ANYSCALAR,

--- a/src/steps/lead-field-equals.ts
+++ b/src/steps/lead-field-equals.ts
@@ -10,7 +10,7 @@ export class LeadFieldEqualsStep extends BaseStep implements StepInterface {
 
   protected stepName: string = 'Check a field on a Marketo Lead';
   // tslint:disable-next-line:max-line-length
-  protected stepExpression: string = 'the (?<field>[a-zA-Z0-9_-]+) field on marketo lead (?<email>.+) should (?<operator>be set|not be set|be less than|be greater than|be|contain|not be|not contain) ?(?<expectation>.+)?';
+  protected stepExpression: string = 'the (?<field>[a-zA-Z0-9_-]+) field on marketo lead (?<email>.+) should (?<operator>be set|not be set|be less than|be greater than|be one of|be|contain|not be one of|not be|not contain) ?(?<expectation>.+)?';
   protected stepType: StepDefinition.Type = StepDefinition.Type.VALIDATION;
   protected expectedFields: Field[] = [{
     field: 'email',
@@ -24,7 +24,7 @@ export class LeadFieldEqualsStep extends BaseStep implements StepInterface {
     field: 'operator',
     type: FieldDefinition.Type.STRING,
     optionality: FieldDefinition.Optionality.OPTIONAL,
-    description: 'Check Logic (be, not be, contain, not contain, be greater than, be less than, be set, or not be set)',
+    description: 'Check Logic (be, not be, contain, not contain, be greater than, be less than, be set, not be set, be one of, or not be one of)',
   }, {
     field: 'expectation',
     type: FieldDefinition.Type.ANYSCALAR,

--- a/test/steps/custom-object-field-equals.ts
+++ b/test/steps/custom-object-field-equals.ts
@@ -29,7 +29,7 @@ describe('CustomObjectFieldEquals', () => {
     const stepDef: StepDefinition = stepUnderTest.getDefinition();
     expect(stepDef.getStepId()).to.equal('CustomObjectFieldEqualsStep');
     expect(stepDef.getName()).to.equal('Check a field on a Marketo Custom Object');
-    expect(stepDef.getExpression()).to.equal('the (?<field>[a-zA-Z0-9_-]+) field on the (?<name>.+) marketo custom object linked to lead (?<linkValue>.+) should (?<operator>be set|not be set|be less than|be greater than|be|contain|not be|not contain) ?(?<expectedValue>.+)?');
+    expect(stepDef.getExpression()).to.equal('the (?<field>[a-zA-Z0-9_-]+) field on the (?<name>.+) marketo custom object linked to lead (?<linkValue>.+) should (?<operator>be set|not be set|be less than|be greater than|be one of|be|contain|not be one of|not be|not contain) ?(?<expectedValue>.+)?');
     expect(stepDef.getType()).to.equal(StepDefinition.Type.VALIDATION);
   });
 

--- a/test/steps/lead-field-equals.ts
+++ b/test/steps/lead-field-equals.ts
@@ -26,7 +26,7 @@ describe('LeadFieldEqualsStep', () => {
     const stepDef: StepDefinition = stepUnderTest.getDefinition();
     expect(stepDef.getStepId()).to.equal('LeadFieldEqualsStep');
     expect(stepDef.getName()).to.equal('Check a field on a Marketo Lead');
-    expect(stepDef.getExpression()).to.equal('the (?<field>[a-zA-Z0-9_-]+) field on marketo lead (?<email>.+) should (?<operator>be set|not be set|be less than|be greater than|be|contain|not be|not contain) ?(?<expectation>.+)?');
+    expect(stepDef.getExpression()).to.equal('the (?<field>[a-zA-Z0-9_-]+) field on marketo lead (?<email>.+) should (?<operator>be set|not be set|be less than|be greater than|be one of|be|contain|not be one of|not be|not contain) ?(?<expectation>.+)?');
     expect(stepDef.getType()).to.equal(StepDefinition.Type.VALIDATION);
   });
 


### PR DESCRIPTION
Added to `Lead` field check step and `Custom Object` field check step.