### PR TITLE
Fixed lead-field-equals step expression

### DIFF
--- a/src/steps/lead-field-equals.ts
+++ b/src/steps/lead-field-equals.ts
@@ -10,7 +10,7 @@ export class LeadFieldEqualsStep extends BaseStep implements StepInterface {
 
   protected stepName: string = 'Check a field on a Marketo Lead';
   // tslint:disable-next-line:max-line-length
-  protected stepExpression: string = 'the (?<field>[a-zA-Z0-9_-]+) field on marketo lead (?<email>.+) should (?<operator>be set|not be set|be less than|be greater than|be one of|be|contain|not be one of|not be|not contain) ?(?<expectation>.+)?';
+  protected stepExpression: string = 'the (?<field>[a-zA-Z0-9_-]+) field on marketo lead (?<email>.+) should (?<operator>be set|not be set|be less than|be greater than|be one of|be|contain|not be one of|not be|not contain) ?(?<expectedValue>.+)?';
   protected stepType: StepDefinition.Type = StepDefinition.Type.VALIDATION;
   protected expectedFields: Field[] = [{
     field: 'email',
@@ -26,7 +26,7 @@ export class LeadFieldEqualsStep extends BaseStep implements StepInterface {
     optionality: FieldDefinition.Optionality.OPTIONAL,
     description: 'Check Logic (be, not be, contain, not contain, be greater than, be less than, be set, not be set, be one of, or not be one of)',
   }, {
-    field: 'expectation',
+    field: 'expectedValue',
     type: FieldDefinition.Type.ANYSCALAR,
     optionality: FieldDefinition.Optionality.OPTIONAL,
     description: 'Expected field value',
@@ -64,7 +64,7 @@ export class LeadFieldEqualsStep extends BaseStep implements StepInterface {
 
   async executeStep(step: Step) {
     const stepData: any = step.getData() ? step.getData().toJavaScript() : {};
-    const expectedValue = stepData.expectation;
+    const expectedValue = stepData.expectedValue;
     const email = stepData.email;
     const operator: string = stepData.operator || 'be';
     const field = stepData.field;

--- a/test/steps/lead-field-equals.ts
+++ b/test/steps/lead-field-equals.ts
@@ -26,7 +26,7 @@ describe('LeadFieldEqualsStep', () => {
     const stepDef: StepDefinition = stepUnderTest.getDefinition();
     expect(stepDef.getStepId()).to.equal('LeadFieldEqualsStep');
     expect(stepDef.getName()).to.equal('Check a field on a Marketo Lead');
-    expect(stepDef.getExpression()).to.equal('the (?<field>[a-zA-Z0-9_-]+) field on marketo lead (?<email>.+) should (?<operator>be set|not be set|be less than|be greater than|be one of|be|contain|not be one of|not be|not contain) ?(?<expectation>.+)?');
+    expect(stepDef.getExpression()).to.equal('the (?<field>[a-zA-Z0-9_-]+) field on marketo lead (?<email>.+) should (?<operator>be set|not be set|be less than|be greater than|be one of|be|contain|not be one of|not be|not contain) ?(?<expectedValue>.+)?');
     expect(stepDef.getType()).to.equal(StepDefinition.Type.VALIDATION);
   });
 
@@ -52,7 +52,7 @@ describe('LeadFieldEqualsStep', () => {
     expect(fields[2].type).to.equal(FieldDefinition.Type.STRING);
 
     // Expectation field
-    expect(fields[3].key).to.equal('expectation');
+    expect(fields[3].key).to.equal('expectedValue');
     expect(fields[3].optionality).to.equal(FieldDefinition.Optionality.OPTIONAL);
     expect(fields[3].type).to.equal(FieldDefinition.Type.ANYSCALAR);
   });
@@ -64,7 +64,7 @@ describe('LeadFieldEqualsStep', () => {
       email: expectedEmail,
       field: expectedField,
       operator: 'be',
-      expectation: expectedEmail,
+      expectedValue: expectedEmail,
     }));
 
     await stepUnderTest.executeStep(protoStep);
@@ -93,7 +93,7 @@ describe('LeadFieldEqualsStep', () => {
 
   it('should respond with an error if the lead found does not contain the given field', async () => {
     protoStep.setData(Struct.fromJavaScript({
-      expectation: 'anything',
+      expectedValue: 'anything',
       email: 'anyone@example.com',
       field: 'firstname',
     }));
@@ -110,10 +110,10 @@ describe('LeadFieldEqualsStep', () => {
     expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
   });
 
-  it('should respond with a failure if the field on the lead does not match the expectation', async () => {
+  it('should respond with a failure if the field on the lead does not match the expectedValue', async () => {
     const expectedValue: string = 'Atoma';
     protoStep.setData(Struct.fromJavaScript({
-      expectation: expectedValue,
+      expectedValue: expectedValue,
       email: 'anyone@example.com',
       field: 'firstName',
     }));
@@ -130,10 +130,10 @@ describe('LeadFieldEqualsStep', () => {
     expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.FAILED);
   });
 
-  it('should respond with a pass if the field on the lead matches the expectation', async () => {
+  it('should respond with a pass if the field on the lead matches the expectedValue', async () => {
     const expectedValue: string = 'Atoma';
     protoStep.setData(Struct.fromJavaScript({
-      expectation: expectedValue,
+      expectedValue: expectedValue,
       email: 'anyone@example.com',
       field: 'firstName',
     }));
@@ -150,10 +150,10 @@ describe('LeadFieldEqualsStep', () => {
     expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
   });
 
-  it("should respond with a pass if the field on the lead matches the expectation with 'be' operator", async () => {
+  it("should respond with a pass if the field on the lead matches the expectedValue with 'be' operator", async () => {
     const expectedValue: string = 'Atoma';
     protoStep.setData(Struct.fromJavaScript({
-      expectation: expectedValue,
+      expectedValue: expectedValue,
       email: 'anyone@example.com',
       field: 'firstName',
       operator: 'be'
@@ -171,10 +171,10 @@ describe('LeadFieldEqualsStep', () => {
     expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
   });
 
-  it("should respond with a pass if the field on the lead matches the expectation with 'contain' operator", async () => {
+  it("should respond with a pass if the field on the lead matches the expectedValue with 'contain' operator", async () => {
     const expectedValue: string = 'Atoma';
     protoStep.setData(Struct.fromJavaScript({
-      expectation: expectedValue,
+      expectedValue: expectedValue,
       email: 'anyone@example.com',
       field: 'firstName',
       operator: 'contain'
@@ -192,10 +192,10 @@ describe('LeadFieldEqualsStep', () => {
     expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
   });
 
-  it("should respond with a pass if the field on the lead satisfies the expectation with number value and 'be greater than' operator", async () => {
+  it("should respond with a pass if the field on the lead satisfies the expectedValue with number value and 'be greater than' operator", async () => {
     const expectedValue: string = '5';
     protoStep.setData(Struct.fromJavaScript({
-      expectation: expectedValue,
+      expectedValue: expectedValue,
       email: 'anyone@example.com',
       field: 'someNumberField',
       operator: 'be greater than',
@@ -214,10 +214,10 @@ describe('LeadFieldEqualsStep', () => {
     expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
   });
 
-  it("should respond with a pass if the field on the lead satisfies the expectation with date value and 'be greater than' operator", async () => {
+  it("should respond with a pass if the field on the lead satisfies the expectedValue with date value and 'be greater than' operator", async () => {
     const expectedValue: string = '2000-01-01';
     protoStep.setData(Struct.fromJavaScript({
-      expectation: expectedValue,
+      expectedValue: expectedValue,
       email: 'anyone@example.com',
       field: 'someDateField',
       operator: 'be greater than',
@@ -236,10 +236,10 @@ describe('LeadFieldEqualsStep', () => {
     expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
   });
 
-  it("should respond with a pass if the field on the lead matches the expectation with 'not be' operator", async () => {
+  it("should respond with a pass if the field on the lead matches the expectedValue with 'not be' operator", async () => {
     const expectedValue: string = 'Atoma';
     protoStep.setData(Struct.fromJavaScript({
-      expectation: expectedValue,
+      expectedValue: expectedValue,
       email: 'anyone@example.com',
       field: 'firstName',
       operator: 'not be'
@@ -257,10 +257,10 @@ describe('LeadFieldEqualsStep', () => {
     expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
   });
 
-  it("should respond with a pass if the field on the lead matches the expectation with 'not contain' operator", async () => {
+  it("should respond with a pass if the field on the lead matches the expectedValue with 'not contain' operator", async () => {
     const expectedValue: string = 'Atoma';
     protoStep.setData(Struct.fromJavaScript({
-      expectation: expectedValue,
+      expectedValue: expectedValue,
       email: 'anyone@example.com',
       field: 'firstName',
       operator: 'not contain'
@@ -278,10 +278,10 @@ describe('LeadFieldEqualsStep', () => {
     expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
   });
 
-  it("should respond with a pass if the field on the lead satisfies the expectation with number value and 'be less than' operator", async () => {
+  it("should respond with a pass if the field on the lead satisfies the expectedValue with number value and 'be less than' operator", async () => {
     const expectedValue: string = '10';
     protoStep.setData(Struct.fromJavaScript({
-      expectation: expectedValue,
+      expectedValue: expectedValue,
       email: 'anyone@example.com',
       field: 'someNumberField',
       operator: 'be less than',
@@ -300,10 +300,10 @@ describe('LeadFieldEqualsStep', () => {
     expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
   });
 
-  it("should respond with a pass if the field on the lead satisfies the expectation with date value and 'be less than' operator", async () => {
+  it("should respond with a pass if the field on the lead satisfies the expectedValue with date value and 'be less than' operator", async () => {
     const expectedValue: string = '2000-02-01';
     protoStep.setData(Struct.fromJavaScript({
-      expectation: expectedValue,
+      expectedValue: expectedValue,
       email: 'anyone@example.com',
       field: 'someDateField',
       operator: 'be less than',
@@ -325,7 +325,7 @@ describe('LeadFieldEqualsStep', () => {
   it("should respond with an error if the field on the lead is not a date or number and 'be less than' operator", async () => {
     const expectedValue: string = 'notANumber';
     protoStep.setData(Struct.fromJavaScript({
-      expectation: expectedValue,
+      expectedValue: expectedValue,
       email: 'anyone@example.com',
       field: 'someDateField',
       operator: 'be less than',
@@ -347,7 +347,7 @@ describe('LeadFieldEqualsStep', () => {
   it("should respond with an error if the field on the lead is not a date or number and 'be greater than' operator", async () => {
     const expectedValue: string = 'notANumber';
     protoStep.setData(Struct.fromJavaScript({
-      expectation: expectedValue,
+      expectedValue: expectedValue,
       email: 'anyone@example.com',
       field: 'someDateField',
       operator: 'be greater than',
@@ -369,7 +369,7 @@ describe('LeadFieldEqualsStep', () => {
   it('should respond with an error if the operator is invalid', async () => {
     const expectedValue: string = '12345';
     protoStep.setData(Struct.fromJavaScript({
-      expectation: expectedValue,
+      expectedValue: expectedValue,
       email: 'anyone@example.com',
       field: 'someDateField',
       operator: 'someOtherOperator',


### PR DESCRIPTION
Updated this since majority of the steps use `expectedValue` than `expectation`.

This also caused a bug in the app wherein it doesn't get rendered properly since only `expectedValue` is understood by the view renderer