### PR TITLE
Marketo Set Operator Fixes

### DIFF
--- a/src/steps/custom-object-field-equals.ts
+++ b/src/steps/custom-object-field-equals.ts
@@ -140,8 +140,12 @@ export class CustomObjectFieldEqualsStep extends BaseStep implements StepInterfa
             [this.table('matchedObjects', `Matched ${customObject.result[0].displayName}`, headers, filteredQueryResult)],
           );
         }
+
+        // Transform the value to `String`. However, cater for `null` or `undefined` by defaulting to `''` first
+        const actualValue = String(filteredQueryResult[0][field] || '');
+
         // Field validation
-        if (this.compare(operator, String(filteredQueryResult[0][field]), expectedValue)) {
+        if (this.compare(operator, actualValue, expectedValue)) {
           return this.pass(
             this.operatorSuccessMessages[operator],
             [field, expectedValue || ''],
@@ -150,7 +154,7 @@ export class CustomObjectFieldEqualsStep extends BaseStep implements StepInterfa
         } else {
           return this.fail(
             this.operatorFailMessages[operator],
-            [field, expectedValue || String(filteredQueryResult[0][field]), String(filteredQueryResult[0][field])],
+            [field, expectedValue || actualValue, actualValue],
             [this.keyValue('customObject', `Checked ${customObject.result[0].displayName}`, filteredQueryResult[0])]);
         }
       } else {

--- a/src/steps/custom-object-field-equals.ts
+++ b/src/steps/custom-object-field-equals.ts
@@ -150,7 +150,7 @@ export class CustomObjectFieldEqualsStep extends BaseStep implements StepInterfa
         } else {
           return this.fail(
             this.operatorFailMessages[operator],
-            [field, expectedValue || '', String(filteredQueryResult[0][field])],
+            [field, expectedValue || String(filteredQueryResult[0][field]), String(filteredQueryResult[0][field])],
             [this.keyValue('customObject', `Checked ${customObject.result[0].displayName}`, filteredQueryResult[0])]);
         }
       } else {

--- a/src/steps/lead-field-equals.ts
+++ b/src/steps/lead-field-equals.ts
@@ -86,7 +86,7 @@ export class LeadFieldEqualsStep extends BaseStep implements StepInterface {
         } else {
           return this.fail(
             this.operatorFailMessages[operator],
-            [field, expectedValue || '', data.result[0][field]],
+            [field, expectedValue || data.result[0][field], data.result[0][field]],
             [this.createRecord(data.result[0])],
           );
         }


### PR DESCRIPTION
# This fixes the following issues:
1. When Set Operator fails, an `(empty value)` string is displayed instead of nothing
this is because the `actualValue` is not being passed for when set operators are used.

<!--
![image](https://user-images.githubusercontent.com/10269901/84640571-7388fa00-af2c-11ea-8049-700f89ce5646.png)
-->

2. For `Custom Objects`, The Set Operators evaluate `null` as passing instead of failing. This is due to `String(actualValue)` constructor calls that attempts to convert the value as string. The fix is to default first to `string empty` before converting to `String`. This is more explained in the image below:

![image](https://user-images.githubusercontent.com/10269901/84651939-5577c580-af3d-11ea-9815-545b45fe1c51.png)
