### PR TITLE
Util update and display fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -187,9 +187,9 @@
       }
     },
     "@run-crank/utilities": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@run-crank/utilities/-/utilities-0.3.0.tgz",
-      "integrity": "sha512-ZG/gSv4OLzC99du5D1gXEF6j3lGp/MrwPrk9cfRY+RGJJcLzT6V34PKLNgQI4z7QG3VnFxUyr6RRXv6VDqjtwg==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@run-crank/utilities/-/utilities-0.3.2.tgz",
+      "integrity": "sha512-OiKEQMJEdGh+NXwjLCynAAXQ1Ru7UyYxIoRJiBAG8MxWCElaIJPk6YJ7xlpTyPMaKB3Ulfe4IQhla5KLXWZkeQ==",
       "requires": {
         "csv-string": "^4.0.1",
         "moment": "^2.24.0"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "typescript": "^3.5.1"
   },
   "dependencies": {
-    "@run-crank/utilities": "^0.3.0",
+    "@run-crank/utilities": "^0.3.2",
     "google-protobuf": "^3.8.0",
     "grpc": "^1.24.3",
     "moment": "^2.24.0",

--- a/src/steps/custom-object-field-equals.ts
+++ b/src/steps/custom-object-field-equals.ts
@@ -63,6 +63,7 @@ export class CustomObjectFieldEqualsStep extends BaseStep implements StepInterfa
     const operator = stepData.operator;
     const expectedValue = stepData.expectedValue;
     const dedupeFields = stepData.dedupeFields;
+    const isSetOperator = ['be set', 'not be set'].includes(operator);
 
     if (isNullOrUndefined(expectedValue) && !(operator == 'be set' || operator == 'not be set')) {
       return this.error("The operator '%s' requires an expected value. Please provide one.", [operator]);
@@ -153,7 +154,7 @@ export class CustomObjectFieldEqualsStep extends BaseStep implements StepInterfa
           const printValue = [null, undefined].includes(filteredQueryResult[0][field]) ? '' : filteredQueryResult[0][field];
           return this.fail(
             this.operatorFailMessages[operator],
-            [field, expectedValue || printValue, printValue],
+            [field, expectedValue || printValue, isSetOperator ? '' : printValue],
             [this.keyValue('customObject', `Checked ${customObject.result[0].displayName}`, filteredQueryResult[0])]);
         }
       } else {

--- a/src/steps/lead-field-equals.ts
+++ b/src/steps/lead-field-equals.ts
@@ -68,6 +68,7 @@ export class LeadFieldEqualsStep extends BaseStep implements StepInterface {
     const email = stepData.email;
     const operator: string = stepData.operator || 'be';
     const field = stepData.field;
+    const isSetOperator = ['be set', 'not be set'].includes(operator);
 
     if (isNullOrUndefined(expectedValue) && !(operator == 'be set' || operator == 'not be set')) {
       return this.error("The operator '%s' requires an expected value. Please provide one.", [operator]);
@@ -86,7 +87,7 @@ export class LeadFieldEqualsStep extends BaseStep implements StepInterface {
         } else {
           return this.fail(
             this.operatorFailMessages[operator],
-            [field, expectedValue || data.result[0][field], data.result[0][field]],
+            [field, expectedValue || (data.result[0][field] || ''), isSetOperator ? '' : data.result[0][field]],
             [this.createRecord(data.result[0])],
           );
         }

--- a/src/steps/lead-field-equals.ts
+++ b/src/steps/lead-field-equals.ts
@@ -85,9 +85,10 @@ export class LeadFieldEqualsStep extends BaseStep implements StepInterface {
             [this.createRecord(data.result[0])],
           );
         } else {
+          const printValue = [null, undefined].includes(data.result[0][field]) ? '' : data.result[0][field];
           return this.fail(
             this.operatorFailMessages[operator],
-            [field, expectedValue || (data.result[0][field] || ''), isSetOperator ? '' : data.result[0][field]],
+            [field, expectedValue || printValue, isSetOperator ? '' : printValue],
             [this.createRecord(data.result[0])],
           );
         }


### PR DESCRIPTION
# Fixed
1. An issue wherein sometimes `(empty value)` is displayed for failing Set Operator displays/messages
2. An issue wherein the `but it was set to <value>` message displays the `<value>` twice.