### PR TITLE
Feature: support duplicated leads (on email) by partition

### DIFF
--- a/test/client/client-wrapper.ts
+++ b/test/client/client-wrapper.ts
@@ -125,6 +125,32 @@ describe('ClientWrapper', () => {
     });
   });
 
+  it('findLeadByEmail (with partition id)', (done) => {
+    const expectedEmail = 'test-in-partition-2@example.com';
+    const expectedPartition = 1;
+
+    marketoClientStub.lead.find = sinon.stub();
+    marketoClientStub.lead.find.returns(Promise.resolve({
+      result: [{
+        email: `not-${expectedEmail}`,
+        leadPartitionId: expectedPartition * 2,
+      }, {
+        email: expectedEmail,
+        leadPartitionId: expectedPartition,
+      }],
+    }));
+
+    clientWrapperUnderTest = new ClientWrapper(metadata, marketoConstructorStub);
+    clientWrapperUnderTest.findLeadByEmail(expectedEmail, null, expectedPartition).then((res) => {
+      try {
+        expect(res.result[0].email).to.equal(expectedEmail);
+      } catch (e) {
+        return done(e);
+      }
+      done();
+    });
+  });
+
   it('deleteLeadById', () => {
     const expectedId = 123;
     clientWrapperUnderTest = new ClientWrapper(metadata, marketoConstructorStub);

--- a/test/steps/lead-delete.ts
+++ b/test/steps/lead-delete.ts
@@ -87,7 +87,7 @@ describe('DeleteLeadStep', () => {
 
   it('should respond with error if the marketo could not find lead', async () => {
     const expectedEmail: string = 'sampleEmail@email.com';
-    const expectedMessage: string = 'a lead with that email address does not exist.';
+    const expectedMessage: string = 'a lead with that email address does not exist';
     protoStep.setData(Struct.fromJavaScript({
       email: expectedEmail,
     }));

--- a/test/steps/lead-field-equals.ts
+++ b/test/steps/lead-field-equals.ts
@@ -55,21 +55,30 @@ describe('LeadFieldEqualsStep', () => {
     expect(fields[3].key).to.equal('expectation');
     expect(fields[3].optionality).to.equal(FieldDefinition.Optionality.OPTIONAL);
     expect(fields[3].type).to.equal(FieldDefinition.Type.ANYSCALAR);
+
+    // Partition ID field
+    expect(fields[4].key).to.equal('partitionId');
+    expect(fields[4].optionality).to.equal(FieldDefinition.Optionality.OPTIONAL);
+    expect(fields[4].type).to.equal(FieldDefinition.Type.NUMERIC);
   });
 
   it('should call the client wrapper with the expected args', async () => {
     const expectedField: string = 'firstName';
     const expectedEmail: string = 'expected@example.com';
+    const expectedPartitionId: number = 3;
     protoStep.setData(Struct.fromJavaScript({
       email: expectedEmail,
       field: expectedField,
       operator: 'be',
       expectation: expectedEmail,
+      partitionId: expectedPartitionId,
     }));
 
     await stepUnderTest.executeStep(protoStep);
     expect(clientWrapperStub.findLeadByEmail).to.have.been.calledWith(
       expectedEmail,
+      sinon.match.any,
+      expectedPartitionId,
     );
   });
 

--- a/test/steps/smart-campaign-add-lead.ts
+++ b/test/steps/smart-campaign-add-lead.ts
@@ -47,6 +47,11 @@ describe('AddLeadToSmartCampaignStep', () => {
     expect(fields[1].key).to.equal('campaign');
     expect(fields[1].optionality).to.equal(FieldDefinition.Optionality.REQUIRED);
     expect(fields[1].type).to.equal(FieldDefinition.Type.ANYSCALAR);
+
+    // Partition ID field
+    expect(fields[2].key).to.equal('partitionId');
+    expect(fields[2].optionality).to.equal(FieldDefinition.Optionality.OPTIONAL);
+    expect(fields[2].type).to.equal(FieldDefinition.Type.NUMERIC);
   });
 
   it('should respond with success if the marketo executes succesfully with non numeric campaign', async () => {


### PR DESCRIPTION
## What / Why
It is possible for Marketo to be configured (by Marketo support) such that the lead's email address is no longer a unique key on the lead table (meaning, there may be more than one lead record per email address).  In this case, Marketo Support configures a custom uniqueness constraint, which is commonly a composite key of email + partition ID.

In order to handle this (relatively uncommon) case, this PR adds an optional `partitionId` field to all affected steps.

Note: the lead create step is unaffected, as it's already possible to specify the partition ID in the lead object definition.