### PR TITLE
Ensured that only fields with rest are being included in Marketo query

### DIFF
--- a/src/client/mixins/lead-aware.ts
+++ b/src/client/mixins/lead-aware.ts
@@ -9,7 +9,7 @@ export class LeadAwareMixin {
 
   public async findLeadByEmail(email: string, justInCaseField: string = null, partitionId: number = null) {
     const fields = await this.describeLeadFields();
-    let fieldList: string[] = fields.result.map((field: any) => field.rest.name);
+    let fieldList: string[] = fields.result.filter(field => field.rest).map((field: any) => field.rest.name);
 
     // If the length of the get request would be over 7KB, then the request
     // would fail. Instead, just hard-code the list of fields to be returned.


### PR DESCRIPTION
What's Changed:
* Ensured that only fields with rest are being included in Marketo query


This causes a weird error for instances that has fields that don't have `field.rest` property.