### PR TITLE
added check-api-usage step and tests

### DIFF
--- a/src/client/client-wrapper.ts
+++ b/src/client/client-wrapper.ts
@@ -2,7 +2,7 @@ import * as grpc from 'grpc';
 import * as Marketo from 'node-marketo-rest';
 import { Field } from '../core/base-step';
 import { FieldDefinition } from '../proto/cog_pb';
-import { LeadAwareMixin, SmartCampaignAwareMixin, ActivityAwareMixin, CustomObjectAwareMixin } from './mixins';
+import { LeadAwareMixin, SmartCampaignAwareMixin, ActivityAwareMixin, CustomObjectAwareMixin, StatsAwareMixin } from './mixins';
 
 class ClientWrapper {
 
@@ -33,10 +33,10 @@ class ClientWrapper {
   }
 }
 
-interface ClientWrapper extends LeadAwareMixin, SmartCampaignAwareMixin, ActivityAwareMixin, CustomObjectAwareMixin {
+interface ClientWrapper extends LeadAwareMixin, SmartCampaignAwareMixin, ActivityAwareMixin, CustomObjectAwareMixin, StatsAwareMixin {
   _connection: any;
 }
-applyMixins(ClientWrapper, [LeadAwareMixin, SmartCampaignAwareMixin, ActivityAwareMixin, CustomObjectAwareMixin]);
+applyMixins(ClientWrapper, [LeadAwareMixin, SmartCampaignAwareMixin, ActivityAwareMixin, CustomObjectAwareMixin, StatsAwareMixin]);
 
 function applyMixins(derivedCtor: any, baseCtors: any[]) {
   baseCtors.forEach((baseCtor) => {

--- a/src/client/mixins/index.ts
+++ b/src/client/mixins/index.ts
@@ -2,3 +2,4 @@ export * from './lead-aware';
 export * from './smart-campaign-aware';
 export * from './activity-aware';
 export * from './custom-object-aware';
+export * from './stats-aware';

--- a/src/client/mixins/stats-aware.ts
+++ b/src/client/mixins/stats-aware.ts
@@ -1,0 +1,9 @@
+import * as Marketo from 'node-marketo-rest';
+
+export class StatsAwareMixin {
+  client: Marketo;
+
+  public async getDailyApiUsage() {
+    return await this.client._connection.get('/v1/stats/usage.json');
+  }
+}

--- a/src/steps/check-api-usage.ts
+++ b/src/steps/check-api-usage.ts
@@ -31,22 +31,16 @@ export class CheckApiUsageStep extends BaseStep implements StepInterface {
 
     try {
       const usage = (await this.client.getDailyApiUsage()).result;
-
-      if (!usage && usage !== []) {
-        return this.fail('Api Usage was not found');
-      }
-
       const dailyUsage = usage.map(record => record.total).reduce((a, b) => a + b, 0);
 
       if (dailyUsage < (0.9 * requestLimit)) {
         return this.pass('Your daily usage is %d, which is less than 90%% of your daily limit of %d.',
                          [dailyUsage, requestLimit],
                          [this.keyValue('requests', 'Checked API Usage', { apiUsage: dailyUsage })]);
-      } else {
-        return this.fail('Your daily usage is %d, which is more than 90%% of your daily limit of %d.',
-                         [dailyUsage, requestLimit],
-                         [this.keyValue('requests', 'Checked API Usage', { apiUsage: dailyUsage })]);
       }
+      return this.fail('Your daily usage is %d, which is more than 90%% of your daily limit of %d.',
+                       [dailyUsage, requestLimit],
+                       [this.keyValue('requests', 'Checked API Usage', { apiUsage: dailyUsage })]);
     } catch (e) {
       return this.error('There was a problem checking the API Usage: %s', [e.toString()]);
     }

--- a/src/steps/check-api-usage.ts
+++ b/src/steps/check-api-usage.ts
@@ -1,0 +1,56 @@
+/*tslint:disable:no-else-after-return*/
+
+import { BaseStep, Field, StepInterface, ExpectedRecord } from '../core/base-step';
+import { Step, FieldDefinition, StepDefinition, RecordDefinition } from '../proto/cog_pb';
+
+export class CheckApiUsageStep extends BaseStep implements StepInterface {
+
+  protected stepName: string = 'Check daily Marketo API usage';
+  protected stepExpression: string = 'there should be less than 90% usage of your daily API limit';
+  protected stepType: StepDefinition.Type = StepDefinition.Type.VALIDATION;
+  protected expectedFields: Field[] = [{
+    field: 'requestLimit',
+    type: FieldDefinition.Type.NUMERIC,
+    optionality: FieldDefinition.Optionality.OPTIONAL,
+    description: 'Your daily API request limit',
+  }];
+  protected expectedRecords: ExpectedRecord[] = [{
+    id: 'requests',
+    type: RecordDefinition.Type.KEYVALUE,
+    fields: [{
+      field: 'apiUsage',
+      type: FieldDefinition.Type.NUMERIC,
+      description: 'Daily API Requests',
+    }],
+    dynamicFields: false,
+  }];
+
+  async executeStep(step: Step) {
+    const stepData: any = step.getData().toJavaScript();
+    const requestLimit: number = stepData.requestLimit ? stepData.requestLimit : 50000;
+
+    try {
+      const usage = (await this.client.getDailyApiUsage()).result;
+
+      if (!usage && usage !== []) {
+        return this.fail('Api Usage was not found');
+      }
+
+      const dailyUsage = usage.map(record => record.total).reduce((a, b) => a + b, 0);
+
+      if (dailyUsage < (0.9 * requestLimit)) {
+        return this.pass('Your daily usage is %d, which is less than 90%% of your daily limit of %d.',
+                         [dailyUsage, requestLimit],
+                         [this.keyValue('requests', 'Checked API Usage', { apiUsage: dailyUsage })]);
+      } else {
+        return this.fail('Your daily usage is %d, which is more than 90%% of your daily limit of %d.',
+                         [dailyUsage, requestLimit],
+                         [this.keyValue('requests', 'Checked API Usage', { apiUsage: dailyUsage })]);
+      }
+    } catch (e) {
+      return this.error('There was a problem checking the API Usage: %s', [e.toString()]);
+    }
+  }
+}
+
+export { CheckApiUsageStep as Step };

--- a/src/steps/check-api-usage.ts
+++ b/src/steps/check-api-usage.ts
@@ -27,7 +27,7 @@ export class CheckApiUsageStep extends BaseStep implements StepInterface {
 
   async executeStep(step: Step) {
     const stepData: any = step.getData().toJavaScript();
-    const requestLimit: number = stepData.requestLimit ? stepData.requestLimit : 50000;
+    const requestLimit = stepData.requestLimit || 50000;
 
     try {
       const usage = (await this.client.getDailyApiUsage()).result;

--- a/test/client/client-wrapper.ts
+++ b/test/client/client-wrapper.ts
@@ -318,4 +318,11 @@ describe('ClientWrapper', () => {
       },
     });
   });
+
+  it('getDailyApiUsage', () => {
+    clientWrapperUnderTest = new ClientWrapper(metadata, marketoConstructorStub);
+    clientWrapperUnderTest.getDailyApiUsage();
+
+    expect(marketoClientStub._connection.get).to.have.been.calledWith('/v1/stats/usage.json');
+  });
 });

--- a/test/steps/check-api-usage.ts
+++ b/test/steps/check-api-usage.ts
@@ -1,0 +1,88 @@
+import { Struct } from 'google-protobuf/google/protobuf/struct_pb';
+import * as chai from 'chai';
+import { default as sinon } from 'ts-sinon';
+import * as sinonChai from 'sinon-chai';
+import 'mocha';
+
+import { Step as ProtoStep, StepDefinition, RunStepResponse } from '../../src/proto/cog_pb';
+import { Step } from '../../src/steps/check-api-usage';
+
+chai.use(sinonChai);
+
+describe('CheckApiUsageStep', () => {
+  const expect = chai.expect;
+  let protoStep: ProtoStep;
+  let stepUnderTest: Step;
+  let clientWrapperStub: any;
+
+  beforeEach(() => {
+    protoStep = new ProtoStep();
+    clientWrapperStub = sinon.stub();
+    clientWrapperStub.getDailyApiUsage = sinon.stub();
+    stepUnderTest = new Step(clientWrapperStub);
+  });
+
+  it('should return expected step metadata', () => {
+    const stepDef: StepDefinition = stepUnderTest.getDefinition();
+    expect(stepDef.getStepId()).to.equal('CheckApiUsageStep');
+    expect(stepDef.getName()).to.equal('Check daily Marketo API usage');
+    expect(stepDef.getExpression()).to.equal('there should be less than 90% usage of your daily API limit');
+    expect(stepDef.getType()).to.equal(StepDefinition.Type.VALIDATION);
+  });
+
+  it('should respond with success if the api calls are less than 90% of the daily limit', async () => {
+    const expectedLimit: number = 10000;
+    protoStep.setData(Struct.fromJavaScript({
+      requestLimit: expectedLimit,
+    }));
+    clientWrapperStub.getDailyApiUsage.returns(Promise.resolve({
+      success: true,
+      result: [
+        {            
+          total: 8999,
+        },
+      ],
+    }));
+    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+  });
+
+  it('should respond with a failure if the api calls are more than 90% of the daily limit', async () => {
+    const expectedLimit: number = 50000;
+    protoStep.setData(Struct.fromJavaScript({
+      requestLimit: expectedLimit,
+    }));
+    clientWrapperStub.getDailyApiUsage.returns(Promise.resolve({
+      success: true,
+      result: [
+        {            
+          total: 49000,
+        },
+      ],
+    }));
+    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.FAILED);
+  });
+
+  it('should respond with a failure if the api calls are not found', async () => {
+    const expectedLimit: number = 50000;
+    protoStep.setData(Struct.fromJavaScript({
+      requestLimit: expectedLimit,
+    }));
+    clientWrapperStub.getDailyApiUsage.returns(Promise.resolve({
+      success: true,
+    }));
+    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.FAILED);
+  });
+
+  it('should respond with an error if the marketo client throws an error', async () => {
+    // Cause the client to throw an error, and execute the step.
+    clientWrapperStub.getDailyApiUsage.throws('any error');
+    protoStep.setData(Struct.fromJavaScript({
+      requestLimit: 50000,
+    }));
+    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
+  });
+});

--- a/test/steps/check-api-usage.ts
+++ b/test/steps/check-api-usage.ts
@@ -64,7 +64,7 @@ describe('CheckApiUsageStep', () => {
     expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.FAILED);
   });
 
-  it('should respond with a failure if the api calls are not found', async () => {
+  it('should respond with an error if no usage is found', async () => {
     const expectedLimit: number = 50000;
     protoStep.setData(Struct.fromJavaScript({
       requestLimit: expectedLimit,
@@ -73,7 +73,7 @@ describe('CheckApiUsageStep', () => {
       success: true,
     }));
     const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
-    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.FAILED);
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
   });
 
   it('should respond with an error if the marketo client throws an error', async () => {


### PR DESCRIPTION
Added a new step to check daily Marketo API usage against the organization's daily limit of API calls.  If a user omits the daily limit field, then it is defaulted to a daily limit of 50,000 calls.

This pull requests includes:

1.  check-api-usage step
2.  stats-aware mixin in the client wrapper
3.  tests for the new step and client wrapper