### PR TITLE
Added weekly API usage

### DIFF
--- a/src/client/mixins/stats-aware.ts
+++ b/src/client/mixins/stats-aware.ts
@@ -6,4 +6,8 @@ export class StatsAwareMixin {
   public async getDailyApiUsage() {
     return await this.client._connection.get('/v1/stats/usage.json');
   }
+
+  public async getWeeklyApiUsage() {
+    return await this.client._connection.get('/v1/stats/usage/last7days.json');
+  }
 }

--- a/test/client/client-wrapper.ts
+++ b/test/client/client-wrapper.ts
@@ -325,4 +325,11 @@ describe('ClientWrapper', () => {
 
     expect(marketoClientStub._connection.get).to.have.been.calledWith('/v1/stats/usage.json');
   });
+
+  it('getWeeklyApiUsage', () => {
+    clientWrapperUnderTest = new ClientWrapper(metadata, marketoConstructorStub);
+    clientWrapperUnderTest.getWeeklyApiUsage();
+
+    expect(marketoClientStub._connection.get).to.have.been.calledWith('/v1/stats/usage/last7days.json');
+  });
 });

--- a/test/steps/check-api-usage.ts
+++ b/test/steps/check-api-usage.ts
@@ -19,6 +19,7 @@ describe('CheckApiUsageStep', () => {
     protoStep = new ProtoStep();
     clientWrapperStub = sinon.stub();
     clientWrapperStub.getDailyApiUsage = sinon.stub();
+    clientWrapperStub.getWeeklyApiUsage = sinon.stub();
     stepUnderTest = new Step(clientWrapperStub);
   });
 
@@ -43,6 +44,14 @@ describe('CheckApiUsageStep', () => {
         },
       ],
     }));
+    clientWrapperStub.getWeeklyApiUsage.returns(Promise.resolve({
+      success: true,
+      result: [
+        {            
+          total: 90000,
+        },
+      ],
+    }));
     const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
     expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
   });
@@ -57,6 +66,14 @@ describe('CheckApiUsageStep', () => {
       result: [
         {            
           total: 49000,
+        },
+      ],
+    }));
+    clientWrapperStub.getWeeklyApiUsage.returns(Promise.resolve({
+      success: true,
+      result: [
+        {            
+          total: 900000,
         },
       ],
     }));


### PR DESCRIPTION
Added getWeeklyApiUsage() to the client wrapper and added a comparison to the message for the the checkApiUsage step.