### PR TITLE
Associate Web Activity Step

### DIFF
--- a/src/client/caching-client-wrapper.ts
+++ b/src/client/caching-client-wrapper.ts
@@ -78,6 +78,11 @@ class CachingClientWrapper {
     }
   }
 
+  public async associateLeadById(leadId: string, cookie: string) {
+    await this.clearCache();
+    return await this.client.associateLeadById(leadId, cookie);
+  }
+
   // custom-object-aware methods
   // -------------------------------------------------------------------
 

--- a/src/client/mixins/lead-aware.ts
+++ b/src/client/mixins/lead-aware.ts
@@ -126,6 +126,11 @@ export class LeadAwareMixin {
     return response;
   }
 
+  public async associateLeadById(leadId: string, cookie: string) {
+    this.delayInSeconds > 0 ? await this.delay(this.delayInSeconds) : null;
+    return await this.client.lead.associateLead(leadId, cookie);
+  }
+
   private async marketoRequestHelperFuntion(fieldList, field, value) {
     const response:any = {};
     let allFields:{ [key: string]: string; } = {};

--- a/src/steps/associate-web-activity.ts
+++ b/src/steps/associate-web-activity.ts
@@ -1,0 +1,64 @@
+/*tslint:disable:no-else-after-return*/
+
+import { BaseStep, Field, StepInterface, ExpectedRecord } from '../core/base-step';
+import { Step, FieldDefinition, StepDefinition, RecordDefinition } from '../proto/cog_pb';
+
+export class AssociateWebActivityStep extends BaseStep implements StepInterface {
+
+  protected stepName: string = 'Associate Web Activity';
+  protected stepExpression: string = 'associate web activity with munchkin cookie (?<munchkinCookie>.+) to marketo lead (?<email>.+\@.+\..+)';
+  protected stepType: StepDefinition.Type = StepDefinition.Type.ACTION;
+  protected expectedFields: Field[] = [
+    {
+      field: 'munchkinCookie',
+      type: FieldDefinition.Type.STRING,
+      description: 'Value of _mkto_trk cookie in browser',
+    },
+    {
+      field: 'email',
+      type: FieldDefinition.Type.EMAIL,
+      description: 'Lead\'s email address',
+    },
+    {
+      field: 'partitionId',
+      type: FieldDefinition.Type.NUMERIC,
+      optionality: FieldDefinition.Optionality.OPTIONAL,
+      description: 'ID of partition lead belongs to',
+      help: 'Only necessary to provide if Marketo has been configured to allow duplicate leads by email.',
+    },
+  ];
+  protected expectedRecords: ExpectedRecord[] = [];
+
+  async executeStep(step: Step) {
+    const stepData: any = step.getData().toJavaScript();
+    const munchkinCookie = stepData.munchkinCookie;
+    const email = stepData.email;
+    const partitionId: number = stepData.partitionId ? parseFloat(stepData.partitionId) : null;
+
+    try {
+      const data: any = await this.client.findLeadByEmail(email, 'id', partitionId);
+
+      if (data.success && data.result && data.result[0] && data.result[0].hasOwnProperty('id')) {
+        const associate: any = await this.client.associateLeadById(data.result[0].id, munchkinCookie);
+
+        if (associate.success && associate.requestId) {
+          return this.pass('Successfully associated munchkin cookie %s with Marketo lead %s', [munchkinCookie, email]);
+        } else {
+          return this.error('Unable to assocated munchkin cookie %s with Marketo lead %s', [munchkinCookie, email]);
+        }
+      } else {
+        return this.error("Couldn't find a lead associated with %s%s", [
+          email,
+          partitionId ? ` in partition ${partitionId}` : '',
+        ]);
+      }
+    } catch (e) {
+      console.log(e);
+      return this.error('There was an error associating the munchkin cookie with the Marketo lead: %s', [
+        e.toString(),
+      ]);
+    }
+  }
+}
+
+export { AssociateWebActivityStep as Step };

--- a/test/steps/associate-web-activity.ts
+++ b/test/steps/associate-web-activity.ts
@@ -1,0 +1,117 @@
+import { Struct } from 'google-protobuf/google/protobuf/struct_pb';
+import * as chai from 'chai';
+import { default as sinon } from 'ts-sinon';
+import * as sinonChai from 'sinon-chai';
+import 'mocha';
+
+import { Step as ProtoStep, StepDefinition, RunStepResponse } from '../../src/proto/cog_pb';
+import { Step } from '../../src/steps/associate-web-activity';
+
+chai.use(sinonChai);
+
+describe('AssociateWebActivityStep', () => {
+  const expect = chai.expect;
+  let protoStep: ProtoStep;
+  let stepUnderTest: Step;
+  let clientWrapperStub: any;
+
+  beforeEach(() => {
+    protoStep = new ProtoStep();
+    clientWrapperStub = sinon.stub();
+    clientWrapperStub.findLeadByEmail = sinon.stub();
+    clientWrapperStub.associateLeadById = sinon.stub();
+    stepUnderTest = new Step(clientWrapperStub);
+  });
+
+  it('should return expected step metadata', () => {
+    const stepDef: StepDefinition = stepUnderTest.getDefinition();
+    expect(stepDef.getStepId()).to.equal('AssociateWebActivityStep');
+    expect(stepDef.getName()).to.equal('Associate Web Activity');
+    expect(stepDef.getExpression()).to.equal('associate web activity with munchkin cookie (?<munchkinCookie>.+) to marketo lead (?<email>.+\@.+\..+)');
+    expect(stepDef.getType()).to.equal(StepDefinition.Type.ACTION);
+  });
+
+  it('should respond with success if the marketo executes succesfully', async () => {
+    const expectedEmail: string = 'sampleEmail@email.com';
+    const expectedCookie: string = 'id:123-ABC-789&token:_mch-stackmoxie.com-1234567891011-12345';
+    protoStep.setData(Struct.fromJavaScript({
+      munchkinCookie: expectedCookie,
+      email: expectedEmail,
+    }));
+    clientWrapperStub.findLeadByEmail.returns(Promise.resolve({
+      success: true,
+      result: [
+        {
+          id: '12345',
+        },
+      ],
+    }));
+    clientWrapperStub.associateLeadById.returns(Promise.resolve({
+      success: true,
+      requestId: '99999',
+    }));
+    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+    expect(response.getMessageArgsList()[0].getStringValue()).to.equal(expectedCookie);
+    expect(response.getMessageArgsList()[1].getStringValue()).to.equal(expectedEmail);
+  });
+
+  it('should respond with error if Marketo is unable to associate the cookie with the lead', async () => {
+    const expectedEmail: string = 'sampleEmail@email.com';
+    const expectedCookie: string = 'id:123-ABC-789&token:_mch-stackmoxie.com-1234567891011-12345';
+    const expectedResponse: string = 'Unable to assocated munchkin cookie %s with Marketo lead %s';
+    protoStep.setData(Struct.fromJavaScript({
+      munchkinCookie: expectedCookie,
+      email: expectedEmail,
+    }));
+    clientWrapperStub.findLeadByEmail.returns(Promise.resolve({
+      success: true,
+      result: [
+        {
+          id: '12345',
+        },
+      ],
+    }));
+    clientWrapperStub.associateLeadById.returns(Promise.resolve({
+      success: false,
+    }));
+    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
+    expect(response.getMessageFormat()).to.equal(expectedResponse);
+    expect(response.getMessageArgsList()[0].getStringValue()).to.equal(expectedCookie);
+    expect(response.getMessageArgsList()[1].getStringValue()).to.equal(expectedEmail);
+  });
+
+  it('should respond with error if Marketo could not find lead', async () => {
+    const expectedEmail: string = 'sampleEmail@email.com';
+    const expectedCookie: string = 'id:123-ABC-789&token:_mch-stackmoxie.com-1234567891011-12345';
+    const expectedMessage: string = "Couldn't find a lead associated with %s%s";
+    protoStep.setData(Struct.fromJavaScript({
+      munchkinCookie: expectedCookie,
+      email: expectedEmail,
+    }));
+    clientWrapperStub.findLeadByEmail.returns(Promise.resolve({
+      success: false,
+    }));
+    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
+    expect(response.getMessageFormat()).to.equal(expectedMessage);
+    expect(response.getMessageArgsList()[0].getStringValue()).to.equal(expectedEmail);
+  });
+
+  it('should respond with error if the marketo throws an error', async () => {
+    const expectedEmail: string = 'sampleEmail@email.com';
+    const expectedCookie: string = 'id:123-ABC-789&token:_mch-stackmoxie.com-1234567891011-12345';
+    const expectedMessage: string = 'There was an error associating the munchkin cookie with the Marketo lead: %s';
+    const expectedError: string = 'any error';
+    protoStep.setData(Struct.fromJavaScript({
+      munchkinCookie: expectedCookie,
+      email: expectedEmail,
+    }));
+    clientWrapperStub.findLeadByEmail.throws(expectedError);
+    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
+    expect(response.getMessageFormat()).to.equal(expectedMessage);
+    expect(response.getMessageArgsList()[0].getStringValue()).to.equal(expectedError);
+  });
+});


### PR DESCRIPTION
New Associate Web Activity Step accepts a _mkto_trk cookie and associates it with a Marketo lead by email.