### PR TITLE
PII suppression in step messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -187,9 +187,9 @@
       }
     },
     "@run-crank/utilities": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@run-crank/utilities/-/utilities-0.5.0.tgz",
-      "integrity": "sha512-gEDbF8hl99dFtg3kN7hEnM4E82RAnX3+8HATXbPWiVIr7zop5SDIL6mlk/QxpHecOlYgM4jebHJ+dqCTdotqVg==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@run-crank/utilities/-/utilities-0.5.1.tgz",
+      "integrity": "sha512-U9YS6zsu7/PCtJl6/PZRcnS8Dh3r4CWLyAg01MhUp7e5rkW2OXZUdosO0RcRYfQHWjs6flz8R2ATTo7TD/jsrQ==",
       "requires": {
         "csv-string": "^4.0.1",
         "moment": "^2.24.0"
@@ -1257,9 +1257,9 @@
       }
     },
     "csv-string": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/csv-string/-/csv-string-4.1.0.tgz",
-      "integrity": "sha512-67UM45fosQvvh+HUvC8iNgg2B4UHWJ5Qud7TWy1EcbIQ9levAFKWudMk2k8U3LgXZP/Drr6eBwBwbSWq2N8HZA=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/csv-string/-/csv-string-4.1.1.tgz",
+      "integrity": "sha512-KGvaJEZEdh2O/EVvczwbPLqJZtSQaWQ4cEJbiOJEG4ALq+dBBqNmBkRXTF4NV79V25+XYtiqbco1IWrmHLm5FQ=="
     },
     "data-uri-to-buffer": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "typescript": "^3.5.1"
   },
   "dependencies": {
-    "@run-crank/utilities": "^0.5.0",
+    "@run-crank/utilities": "^0.5.1",
     "google-protobuf": "^3.8.0",
     "grpc": "^1.24.3",
     "mailgun-js": "^0.22.0",

--- a/src/core/base-step.ts
+++ b/src/core/base-step.ts
@@ -85,8 +85,8 @@ export abstract class BaseStep {
     return stepDefinition;
   }
 
-  assert(operator: string, actualValue: string, expectedValue: string, field: string): util.AssertionResult {
-    return util.assert(operator, actualValue, expectedValue, field);
+  assert(operator: string, actualValue: string, expectedValue: string, field: string, piiLevel: string = null): util.AssertionResult {
+    return util.assert(operator, actualValue, expectedValue, field, piiLevel);
   }
 
   protected pass(message: string, messageArgs: any[] = [], records: StepRecord[] = []): RunStepResponse {

--- a/src/steps/bulk-lead-field-equals.ts
+++ b/src/steps/bulk-lead-field-equals.ts
@@ -107,7 +107,7 @@ export class BulkLeadFieldEqualsStep extends BaseStep implements StepInterface {
           });
           batch.result.forEach((result) => {
             if (result.hasOwnProperty(field)) {
-              const assertResult = this.assert(operator, result[field], expectedValue, field);
+              const assertResult = this.assert(operator, result[field], expectedValue, field, stepData['__piiSuppressionLevel']);
               if (assertResult.valid) {
                 successArray.push({ email: result.email, id: result.id, message: assertResult.message });
               } else {

--- a/src/steps/custom-object-field-equals.ts
+++ b/src/steps/custom-object-field-equals.ts
@@ -153,7 +153,7 @@ export class CustomObjectFieldEqualsStep extends BaseStep implements StepInterfa
         }
 
         // Field validation
-        const result = this.assert(operator, filteredQueryResult[0][field], expectedValue, field);
+        const result = this.assert(operator, filteredQueryResult[0][field], expectedValue, field, stepData['__piiSuppressionLevel']);
         const record = this.keyValue('customObject', `Checked ${customObject.result[0].displayName}`, filteredQueryResult[0]);
         const orderedRecord = this.keyValue(`customObject.${stepData['__stepOrder']}`, `Checked ${customObject.result[0].displayName} from Step ${stepData['__stepOrder']}`, filteredQueryResult[0]);
 

--- a/src/steps/lead-by-id-field-equals.ts
+++ b/src/steps/lead-by-id-field-equals.ts
@@ -84,7 +84,7 @@ export class LeadByIdFieldEqualsStep extends BaseStep implements StepInterface {
       const data: any = await this.client.findLeadByField('id', leadId, field, partitionId);
 
       if (data.success && data.result && data.result[0] && data.result[0].hasOwnProperty(field)) {
-        const result = this.assert(operator, data.result[0][field], expectedValue, field);
+        const result = this.assert(operator, data.result[0][field], expectedValue, field, stepData['__piiSuppressionLevel']);
         const record = this.createRecord(data.result[0]);
         const orderedRecord = this.createOrderedRecord(data.result[0], stepData['__stepOrder']);
         return result.valid ? this.pass(result.message, [], [record, orderedRecord])

--- a/src/steps/lead-field-equals.ts
+++ b/src/steps/lead-field-equals.ts
@@ -90,7 +90,7 @@ export class LeadFieldEqualsStep extends BaseStep implements StepInterface {
       const data: any = await this.client.findLeadByField(lookupField, reference, field, partitionId);
 
       if (data.success && data.result && data.result[0] && data.result[0].hasOwnProperty(field)) {
-        const result = this.assert(operator, data.result[0][field], expectedValue, field);
+        const result = this.assert(operator, data.result[0][field], expectedValue, field, stepData['__piiSuppressionLevel']);
 
         const record = this.createRecord(data.result[0]);
         const orderedRecord = this.createOrderedRecord(data.result[0], stepData['__stepOrder']);

--- a/src/steps/program-members/program-member-field-equals.ts
+++ b/src/steps/program-members/program-member-field-equals.ts
@@ -100,7 +100,7 @@ export class ProgramMemberFieldEqualsStep extends BaseStep implements StepInterf
 
       if (data.success && data.result && data.result[0] && data.result[0].hasOwnProperty(field)) {
         let result;
-        result = this.assert(operator, data.result[0][field], expectedValue, field);
+        result = this.assert(operator, data.result[0][field], expectedValue, field, stepData['__piiSuppressionLevel']);
         const record = this.createRecord(data.result[0]);
         const orderedRecord = this.createOrderedRecord(data.result[0], stepData['__stepOrder']);
         return result.valid ? this.pass(result.message, [], [record, orderedRecord])

--- a/src/steps/programs/program-field-equals.ts
+++ b/src/steps/programs/program-field-equals.ts
@@ -81,11 +81,11 @@ export class ProgramFieldEqualsStep extends BaseStep implements StepInterface {
         const totalCost = this.getTotalProjectCost(data.result[0]);
         data.result[0].costs = totalCost;
         if (field === 'folder') {
-          result = this.assert(operator, data.result[0]['folder']['folderName'], expectedValue, field);
+          result = this.assert(operator, data.result[0]['folder']['folderName'], expectedValue, field, stepData['__piiSuppressionLevel']);
         } else if (field === 'costs') {
-          result = this.assert(operator, totalCost.toString(), expectedValue, field);
+          result = this.assert(operator, totalCost.toString(), expectedValue, field, stepData['__piiSuppressionLevel']);
         } else {
-          result = this.assert(operator, data.result[0][field].trim(), expectedValue.trim(), field);
+          result = this.assert(operator, data.result[0][field].trim(), expectedValue.trim(), field, stepData['__piiSuppressionLevel']);
         }
 
         const record = this.createRecord(data.result[0]);


### PR DESCRIPTION
- Update typescript cog utilities
- Some step messages will have PII removed if a "__piiSuppressionLevel" is passed in the stepData