### PR TITLE
Check Lead Activity Step: Added bulk functionality | Other Marketo Fixes

### DIFF
--- a/src/client/mixins/activity-aware.ts
+++ b/src/client/mixins/activity-aware.ts
@@ -14,15 +14,82 @@ export class ActivityAwareMixin {
     return await this.client._connection.get(`/v1/activities/pagingtoken.json?sinceDatetime=${sinceDate}`);
   }
 
-  public async getActivitiesByLeadId(nextPageToken, leadId, activityId) {
+  public async getActivitiesByLeadId(nextPageToken, leadIdInput, activityId) {
+    // NOTE: leadId can be either a single ID or an array of IDs
+    const leadId = JSON.parse(JSON.stringify(leadIdInput)); // Make a copy since it can be mutated
     this.delayInSeconds > 0 ? await this.delay(this.delayInSeconds) : null;
-    return await this.client._connection.get('/v1/activities.json', {
-      query: {
-        nextPageToken,
-        leadIds: leadId,
-        activityTypeIds: activityId,
-      },
-    });
+
+    const output = {
+      success: true,
+      result: [],
+    };
+
+    try {
+      // Handle bulk check of more than 30 leads (endpoint can accept a max of 30 IDs, so we need to batch them)
+      if (Array.isArray(leadId) && leadId.length > 30) {
+        const batches = [];
+
+        while (leadId.length > 0) {
+          batches.push(leadId.splice(0, 30));
+        }
+
+        for (let i = 0; i < batches.length; i += 1) {
+          let curr = await this.client._connection.get('/v1/activities.json', {
+            query: {
+              nextPageToken,
+              leadIds: batches[i].join(','),
+              activityTypeIds: activityId,
+            },
+          });
+          output.result.push(...curr.result);
+
+          let count = 0;
+          // Pull activities up to 10 times total (3000 activities) per batch
+          while (curr.moreResult && count < 10) {
+            curr = await this.client._connection.get('/v1/activities.json', {
+              query: {
+                nextPageToken: curr.nextPageToken,
+                leadIds: Array.isArray(leadId) ? leadId.join(',') : leadId,
+                activityTypeIds: activityId,
+              },
+            });
+
+            output.result.push(...curr.result);
+            count += 1;
+          }
+        }
+      } else {
+        // Handle single lead check or bulk check of up to 30 leads
+        let res = await this.client._connection.get('/v1/activities.json', {
+          query: {
+            nextPageToken,
+            leadIds: Array.isArray(leadId) ? leadId.join(',') : leadId,
+            activityTypeIds: activityId,
+          },
+        });
+        output.result.push(...res.result);
+
+        let count = 0;
+        // Pull activities up to 10 times total (3000 activities)
+        while (res.moreResult && count < 10) {
+          res = await this.client._connection.get('/v1/activities.json', {
+            query: {
+              nextPageToken: res.nextPageToken,
+              leadIds: Array.isArray(leadId) ? leadId.join(',') : leadId,
+              activityTypeIds: activityId,
+            },
+          });
+
+          output.result.push(...res.result);
+          count += 1;
+        }
+      }
+    } catch (e) {
+      output.success = false;
+    } finally {
+      return output;
+    }
+
   }
 
   public async getActivities(nextPageToken, activityId) {

--- a/src/client/mixins/lead-aware.ts
+++ b/src/client/mixins/lead-aware.ts
@@ -52,6 +52,11 @@ export class LeadAwareMixin {
       return Promise.resolve({ error: { partition: false } });
     }
 
+    if (!lead[lookupField]) {
+      // If the email/Id is not on the lead object, add it
+      lead[lookupField] = value;
+    }
+
     const requestBody = {
       lookupField,
       action: 'updateOnly',
@@ -147,7 +152,6 @@ export class LeadAwareMixin {
   }
 
   public async bulkFindLeadsByEmail(emails: [], justInCaseField: string = null, partitionId: number = null) {
-    console.log('partitionId:', partitionId);
     this.delayInSeconds > 0 ? await this.delay(this.delayInSeconds) : null;
     const fields = await this.describeLeadFields();
     const fieldList: string[] = fields.result.filter(field => field.rest).map((field: any) => field.rest.name);
@@ -161,7 +165,6 @@ export class LeadAwareMixin {
       response = await this.client.lead.find('email', chunkedEmails[i], { fields: [justInCaseField, ...this.mustHaveFields, partitionId ? 'leadPartitionId' : null] });
       responseArray.push(response);
     }
-    console.log('responseArray before filtering partition:', responseArray);
 
     // If a partition ID was provided, filter the returned leads accordingly.
     responseArray.forEach((response) => {
@@ -171,8 +174,6 @@ export class LeadAwareMixin {
         });
       }
     });
-
-    console.log('responseArray after filtering partition:', responseArray);
 
     return responseArray;
   }

--- a/src/steps/check-lead-activity.ts
+++ b/src/steps/check-lead-activity.ts
@@ -2,7 +2,7 @@ import { titleCase } from 'title-case';
 /*tslint:disable:no-else-after-return*/
 
 import { BaseStep, Field, StepInterface, ExpectedRecord } from '../core/base-step';
-import { Step, FieldDefinition, StepDefinition, RecordDefinition } from '../proto/cog_pb';
+import { Step, FieldDefinition, StepDefinition, RecordDefinition, StepRecord } from '../proto/cog_pb';
 
 import * as moment from 'moment';
 
@@ -61,6 +61,47 @@ export class CheckLeadActivityStep extends BaseStep implements StepInterface {
       description: "Activity Type's ID",
     }],
     dynamicFields: true,
+  }, {
+    id: 'passedLeads',
+    type: RecordDefinition.Type.TABLE,
+    fields: [{
+      field: 'id',
+      type: FieldDefinition.Type.NUMERIC,
+      description: 'ID of Marketo Lead',
+    }, {
+      field: 'email',
+      type: FieldDefinition.Type.EMAIL,
+      description: 'email of Marketo Lead (if provided)',
+    }, {
+      field: 'activityId',
+      type: FieldDefinition.Type.NUMERIC,
+      description: "Activity's ID",
+    }, {
+      field: 'activityDate',
+      type: FieldDefinition.Type.DATETIME,
+      description: "Activity's Date",
+    }, {
+      field: 'activityTypeId',
+      type: FieldDefinition.Type.NUMERIC,
+      description: "Activity Type's ID",
+    }],
+  }, {
+    id: 'failedLeads',
+    type: RecordDefinition.Type.TABLE,
+    fields: [{
+      field: 'id',
+      type: FieldDefinition.Type.NUMERIC,
+      description: 'ID of Marketo Lead',
+    }, {
+      field: 'email',
+      type: FieldDefinition.Type.EMAIL,
+      description: 'email of Marketo Lead (if provided)',
+    }, {
+      field: 'message',
+      type: FieldDefinition.Type.STRING,
+      description: 'Message for explanation of fail',
+    }],
+    dynamicFields: false,
   }];
 
   async executeStep(step: Step) {
@@ -80,23 +121,8 @@ export class CheckLeadActivityStep extends BaseStep implements StepInterface {
 
       const emailRegex = /(.+)@(.+){2,}\.(.+){2,}/;
       let lookupField = 'id';
-      if (emailRegex.test(reference)) {
-        lookupField = 'email';
-      }
-
-      const lead = (await this.client.findLeadByField(lookupField, reference, null, partitionId)).result[0];
-
-      /* Error when lead is not found */
-      if (!lead) {
-        return this.fail('Lead %s was not found%s', [
-          reference,
-          partitionId ? ` in partition ${partitionId}` : '',
-        ]);
-      }
-
       const activityTypes = (await this.client.getActivityTypes()).result;
       const activityType = activityTypes.find(type => type[isNaN(activityTypeIdOrName) ? 'name' : 'id'] == activityTypeIdOrName);
-
       /* Error when activity is not found */
       if (!activityType) {
         return this.error('%s is not a known activity type.', [
@@ -106,77 +132,303 @@ export class CheckLeadActivityStep extends BaseStep implements StepInterface {
 
       activityTypeIdOrName = activityType.id;
 
-      const activityResponse = await this.client.getActivitiesByLeadId(nextPageToken, lead.id, activityTypeIdOrName);
-      const activities = activityResponse.result;
-
-      /* Fail when when the activity supplied is not found in the lead's logs. */
-      if (!activities) {
-        return this[includes ? 'fail' : 'pass']('No %s activity found for lead %s within the last %d minute(s)', [
-          stepData.activityTypeIdOrName,
-          reference,
-          minutesAgo,
-        ]);
-      }
-
       /* Expected attributes passed to test step. Translate object/map as array for easier comparison with actual attributes */
       const expectedAttributes = Object.keys(withAttributes).map((key) => { return { name: key, value: withAttributes[key] }; });
-      let validatedActivity;
+      if ((stepData.multiple_email && Array.isArray(stepData.multiple_email) && stepData.multiple_email.length > 0) ||
+          (stepData.multiple_id && Array.isArray(stepData.multiple_id) && stepData.multiple_id.length > 0)) {
+        // Checking multiple leads
+        console.log('multiple leads provided, performing bulk check');
+        const leadIds = stepData.multiple_id || [];
+        const leadEmails = {};
+        const failedArray = [];
+        const passedArray = [];
 
-      /* Assert Actual vs Expected attributes and pass if at least one activity matches attributes. Otherwise fail */
-      if (expectedAttributes.length > 0) {
-        let validated = false;
-        for (const activity of activities) {
-          const primaryAttribute = this.getPrimaryAttribute(activityTypes, activity);
-          const actualAttributes = activity.attributes;
+        // If email is provided, first fetch all the leads and get their IDs
+        if (stepData.multiple_email && stepData.multiple_email.length > 0) {
+          lookupField = 'email';
+          const response = await this.client.bulkFindLeadsByEmail(stepData.multiple_email, null, partitionId);
 
-          Object.keys(activity).forEach((key) => {
-            if (key !== 'attributes') {
-              actualAttributes.push({
-                name: key,
-                value: activity[key],
-              });
-            }
+          if (!response[0].success) {
+            return this.error('There was an error finding the leads in Marketo', [], []);
+          }
+
+          const leads = response[0].result;
+
+           // Error if any leads aren't found
+          if (leads.length !== stepData.multiple_email.length) {
+            return this.fail('Not all leads were found%s', [
+              partitionId ? ` in partition ${partitionId}` : '',
+            ]);
+          }
+
+          await leads.forEach((lead) => {
+            leadIds.push(lead.id);
+            leadEmails[lead.id] = lead.email;
           });
+        }
+        const activityResponse = await this.client.getActivitiesByLeadId(nextPageToken, leadIds, activityTypeIdOrName);
+        const activities = activityResponse.result;
 
-          if (primaryAttribute) {
-            actualAttributes.push(primaryAttribute);
+        // Fail when when no activities were found for any leads.
+        if (!activities.length) {
+          return this[includes ? 'fail' : 'pass']('No %s activity found for the provided leads within the last %d minute(s)', [
+            stepData.activityTypeIdOrName,
+            minutesAgo,
+          ]);
+        }
+
+        // Loop through all leads
+        for (const leadId of leadIds) {
+          // Filter out all activities for current lead
+          const currLeadActivities = activities.filter(act => act.leadId === leadId);
+          const leadEmail = leadEmails[leadId] || '';
+
+          if (!currLeadActivities.length) {
+            // If no activities are found, push to failed array
+            failedArray.push({ id: leadId, email: leadEmail, message: `No activities found for lead ${lookupField === 'email' ? leadEmail : leadId} within the last ${minutesAgo} minute(s)` });
+            continue;
           }
 
-          if (this.hasMatchingAttributes(actualAttributes, expectedAttributes)) {
-            validated = true;
-            validatedActivity = activity;
-            break;
+          if (!expectedAttributes.length) {
+            // If there are no additional attributes to check, push first activity that matches to passed array
+            const first = currLeadActivities[0];
+            passedArray.push({ id: leadId, email: leadEmail, activityId: first.id, activityTypeId: first.activityTypeId, activityDate: first.activityDate });
+            continue;
+          } else {
+            // If there are expected attributes, loop through each of currLeadActivities
+            let validated = false;
+            let validatedActivity;
+
+            for (const activity of currLeadActivities) {
+              const primaryAttribute = this.getPrimaryAttribute(activityTypes, activity);
+              const actualAttributes = activity.attributes;
+
+              Object.keys(activity).forEach((key) => {
+                if (key !== 'attributes') {
+                  actualAttributes.push({
+                    name: key,
+                    value: activity[key],
+                  });
+                }
+              });
+
+              if (primaryAttribute) {
+                actualAttributes.push(primaryAttribute);
+              }
+
+              // Check if expected atributes are on current activity
+              if (this.hasMatchingAttributes(actualAttributes, expectedAttributes)) {
+                validated = true;
+                validatedActivity = activity;
+                break;
+              }
+            }
+
+            if (validated) {
+              // If there was an activity with all expected attributes, push to passed array
+              passedArray.push({ id: leadId, email: leadEmail, activityId: validatedActivity.id, activityTypeId: validatedActivity.activityTypeId, activityDate: validatedActivity.activityDate });
+              continue;
+            } else {
+              // If none contain all expected attributes, push to fail array
+              failedArray.push({ id: leadId, email: leadEmail, message: `Found ${activityTypeIdOrName} activity for lead ${leadEmail || leadId} within the last ${minutesAgo} minute(s), but none matched the expected attributes ${expectedAttributes.map(attr => `${attr.name} = ${attr.value}`).join(', ')}` });
+            }
           }
         }
 
-        if (validated) {
-          return this[includes ? 'pass' : 'fail'](
-            'Found %s activity for lead %s within the last %d minute(s), including attributes: \n\n%s',
-            [stepData.activityTypeIdOrName, reference, minutesAgo, JSON.stringify(expectedAttributes, null, 2)],
-            [this.createRecord(validatedActivity)],
-          );
+        const records = [];
+        if (includes) {
+          // When user is expecting activities to be found
+          if (!failedArray.length) {
+            // all leads passed
+            records.push(this.createTable('passedLeads', 'Leads Passed', passedArray));
+            if (expectedAttributes.length) {
+              return this.pass(
+                'Found %s activity for all leads within the last %d minute(s), including attributes: \n\n%s',
+                [stepData.activityTypeIdOrName, minutesAgo, JSON.stringify(expectedAttributes, null, 2)],
+                records,
+              );
+            } else {
+              return this.pass(
+                'Found %s activity for all leads within the last %d minute(s)',
+                [stepData.activityTypeIdOrName, minutesAgo],
+                records,
+              );
+            }
+
+          } else if (failedArray.length && passedArray.length) {
+            // some leads passed and some failed
+            records.push(this.createTable('passedLeads', 'Leads Passed', passedArray));
+            records.push(this.createTable('failedLeads', 'Leads Failed', failedArray));
+            if (expectedAttributes.length) {
+              return this.fail(
+                'Found %s activity for %d out of %d leads within the last %d minute(s), including attributes: \n\n%s',
+                [stepData.activityTypeIdOrName, passedArray.length, leadIds.length, minutesAgo, JSON.stringify(expectedAttributes, null, 2)],
+                records,
+              );
+            } else {
+              return this.fail(
+                'Found %s activity for %d out of %d leads within the last %d minute(s)',
+                [stepData.activityTypeIdOrName, passedArray.length, leadIds.length, minutesAgo],
+                records,
+              );
+            }
+          } else {
+            // all leads failed
+            records.push(this.createTable('failedLeads', 'Leads Failed', failedArray));
+            if (expectedAttributes.length) {
+              return this.fail(
+                'Did not find %s activity for any leads within the last %d minute(s) that included attributes: \n\n%s',
+                [stepData.activityTypeIdOrName, minutesAgo, JSON.stringify(expectedAttributes, null, 2)],
+                records,
+              );
+            } else {
+              return this.fail(
+                'Did not find %s activity for any leads within the last %d minute(s)',
+                [stepData.activityTypeIdOrName, minutesAgo],
+                records,
+              );
+            }
+          }
+        } else {
+          // When user is expecting NO activities to be found
+          // NOTE: passed and failed arrays still contain the same info (passed = leads where the activity was found), but mean the opposite in this else block
+          if (!passedArray.length) {
+            // no activities were found, so the step passes
+            records.push(this.createTable('passedLeads', 'Leads Passed', failedArray));
+            if (expectedAttributes.length) {
+              return this.pass(
+                'Did not find %s activity for any leads within the last %d minute(s) that included attributes: \n\n%s',
+                [stepData.activityTypeIdOrName, minutesAgo, JSON.stringify(expectedAttributes, null, 2)],
+                records,
+              );
+            } else {
+              return this.pass(
+                'Did not find %s activity for any leads within the last %d minute(s)',
+                [stepData.activityTypeIdOrName, minutesAgo],
+                records,
+              );
+            }
+          } else if (failedArray.length && passedArray.length) {
+            // some leads passed and some failed
+            records.push(this.createTable('passedLeads', 'Leads Passed', failedArray)); // Note these are flipped intentionally, as the passedLeads record should contain leads where the activity was not found
+            records.push(this.createTable('failedLeads', 'Leads Failed', passedArray));
+            if (expectedAttributes.length) {
+              return this.fail(
+                'Found %s activity for %d out of %d leads within the last %d minute(s), including attributes: \n\n%s',
+                [stepData.activityTypeIdOrName, passedArray.length, leadIds.length, minutesAgo, JSON.stringify(expectedAttributes, null, 2)],
+                records,
+              );
+            } else {
+              return this.fail(
+                'Found %s activity for %d out of %d leads within the last %d minute(s)',
+                [stepData.activityTypeIdOrName, passedArray.length, leadIds.length, minutesAgo],
+                records,
+              );
+            }
+          } else {
+            // all activities were found, so the step fails
+            records.push(this.createTable('failedLeads', 'Leads Failed', passedArray));
+            if (expectedAttributes.length) {
+              return this.fail(
+                'Found %s activity for all leads within the last %d minute(s), including attributes: \n\n%s',
+                [stepData.activityTypeIdOrName, minutesAgo, JSON.stringify(expectedAttributes, null, 2)],
+                records,
+              );
+            } else {
+              return this.fail(
+                'Found %s activity for all leads within the last %d minute(s)',
+                [stepData.activityTypeIdOrName, minutesAgo],
+                records,
+              );
+            }
+          }
         }
 
-        const activityRecords = this.createRecords(activities);
-        activityRecords.setName(`Matched "${activityType.name}" Activities`);
+      } else {
+        // Only checking one lead
+        if (emailRegex.test(reference)) {
+          lookupField = 'email';
+        }
 
-        return this[includes ? 'fail' : 'pass'](
-          'Found %s activity for lead %s within the last %d minute(s), but none matched the expected attributes (%s).',
-          [
+        const lead = (await this.client.findLeadByField(lookupField, reference, null, partitionId)).result[0];
+
+        /* Error when lead is not found */
+        if (!lead) {
+          return this.fail('Lead %s was not found%s', [
+            reference,
+            partitionId ? ` in partition ${partitionId}` : '',
+          ]);
+        }
+
+        const activityResponse = await this.client.getActivitiesByLeadId(nextPageToken, lead.id, activityTypeIdOrName);
+        const activities = activityResponse.result;
+
+        /* Fail when when the activity supplied is not found in the lead's logs. */
+        if (!activities.length) {
+          return this[includes ? 'fail' : 'pass']('No %s activity found for lead %s within the last %d minute(s)', [
             stepData.activityTypeIdOrName,
             reference,
             minutesAgo,
-            expectedAttributes.map(attr => `${attr.name} = ${attr.value}`).join(', '),
-          ],
-          [activityRecords],
+          ]);
+        }
+
+        /* Assert Actual vs Expected attributes and pass if at least one activity matches attributes. Otherwise fail */
+        if (expectedAttributes.length > 0) {
+          let validated = false;
+          let validatedActivity;
+          for (const activity of activities) {
+            const primaryAttribute = this.getPrimaryAttribute(activityTypes, activity);
+            const actualAttributes = activity.attributes;
+
+            Object.keys(activity).forEach((key) => {
+              if (key !== 'attributes') {
+                actualAttributes.push({
+                  name: key,
+                  value: activity[key],
+                });
+              }
+            });
+
+            if (primaryAttribute) {
+              actualAttributes.push(primaryAttribute);
+            }
+
+            if (this.hasMatchingAttributes(actualAttributes, expectedAttributes)) {
+              validated = true;
+              validatedActivity = activity;
+              break;
+            }
+          }
+
+          if (validated) {
+            return this[includes ? 'pass' : 'fail'](
+              'Found %s activity for lead %s within the last %d minute(s), including attributes: \n\n%s',
+              [stepData.activityTypeIdOrName, reference, minutesAgo, JSON.stringify(expectedAttributes, null, 2)],
+              [this.createRecord(validatedActivity)],
+            );
+          }
+
+          const activityRecords = this.createRecords(activities);
+          activityRecords.setName(`Matched "${activityType.name}" Activities`);
+
+          return this[includes ? 'fail' : 'pass'](
+            'Found %s activity for lead %s within the last %d minute(s), but none matched the expected attributes (%s).',
+            [
+              stepData.activityTypeIdOrName,
+              reference,
+              minutesAgo,
+              expectedAttributes.map(attr => `${attr.name} = ${attr.value}`).join(', '),
+            ],
+            [activityRecords],
+          );
+        }
+
+        return this[includes ? 'pass' : 'fail'](
+          '%s activity found for lead %s within the last %d minute(s)',
+          [stepData.activityTypeIdOrName, reference, minutesAgo],
+          [this.createRecord(activities[0])],
         );
       }
-
-      return this[includes ? 'pass' : 'fail'](
-        '%s activity found for lead %s within the last %d minute(s)',
-        [stepData.activityTypeIdOrName, reference, minutesAgo],
-        [this.createRecord(activities[0])],
-      );
 
     } catch (e) {
       return this.error('There was an error checking activities for Marketo Lead: %s', [
@@ -208,6 +460,7 @@ export class CheckLeadActivityStep extends BaseStep implements StepInterface {
     return result;
   }
 
+  // Used only by singular version of this step, not used when checking multiple leads at once
   createRecords(activities) {
     const records = [];
     const headers = { id: 'ID', leadId: 'Lead ID', activityDate: 'Activity Date', activityTypeId: 'Activity Type ID' };
@@ -229,6 +482,16 @@ export class CheckLeadActivityStep extends BaseStep implements StepInterface {
     }
 
     return this.keyValue('activity', 'Checked Activity', activity);
+  }
+
+  // Used only by bulk version of this step
+  createTable(id: string, name: string, leads: any[]): StepRecord {
+    const headers = {};
+    const headerKeys = Object.keys(leads[0] || {});
+    headerKeys.forEach((key: string) => {
+      headers[key] = key;
+    });
+    return this.table(id, name, headers, leads);
   }
 }
 

--- a/src/steps/lead-field-equals.ts
+++ b/src/steps/lead-field-equals.ts
@@ -117,13 +117,10 @@ export class LeadFieldEqualsStep extends BaseStep implements StepInterface {
     if (stepData.multiple_email && Array.isArray(stepData.multiple_email) && stepData.multiple_email.length > 0) {
       try {
         // Checking multiple leads
-        console.log('multiple leads found, performing bulk check');
         const emailArray = stepData.multiple_email;
-        console.log('emailArray:', emailArray);
         const successArray = [];
         const failArray = [];
         const data: any = await this.client.bulkFindLeadsByEmail(emailArray, field, partitionId);
-        console.log('data:', data);
         const indexMap = {}; // Only needed if using dynamic multiple leads with different expected values
 
         // Check if the expectedValue is dynamic
@@ -145,8 +142,6 @@ export class LeadFieldEqualsStep extends BaseStep implements StepInterface {
           const startingIndex = i * 300;
           const emailSubarray = emailArray.slice(startingIndex, startingIndex + 300);
           if (batch.success && batch.result) {
-            console.log('batch.result:', batch.result);
-            console.log('batch.result stringified:', JSON.stringify(batch.result));
             // If an email is missing from the response, then add it to the failArray
             emailSubarray.forEach((email) => {
               if (batch.result.filter(result => email === result.email).length === 0) {
@@ -219,7 +214,6 @@ export class LeadFieldEqualsStep extends BaseStep implements StepInterface {
     } else {
       // Only checking one lead
       try {
-        console.log('one lead found, performing single check');
         const emailRegex = /(.+)@(.+){2,}\.(.+){2,}/;
         let lookupField = 'id';
         if (emailRegex.test(reference)) {

--- a/test/steps/lead-field-equals.ts
+++ b/test/steps/lead-field-equals.ts
@@ -14,398 +14,1026 @@ describe('LeadFieldEqualsStep', () => {
   let protoStep: ProtoStep;
   let stepUnderTest: Step;
   let clientWrapperStub: any;
+  
+  describe('Single Lead Check', () => {
 
-  beforeEach(() => {
-    protoStep = new ProtoStep();
-    clientWrapperStub = sinon.stub();
-    clientWrapperStub.findLeadByField = sinon.stub();
-    stepUnderTest = new Step(clientWrapperStub);
-  });
-
-  it('should return expected step metadata', () => {
-    const stepDef: StepDefinition = stepUnderTest.getDefinition();
-    expect(stepDef.getStepId()).to.equal('LeadFieldEqualsStep');
-    expect(stepDef.getName()).to.equal('Check a field on a Marketo Lead');
-    expect(stepDef.getExpression()).to.equal('the (?<field>[a-zA-Z0-9_-]+) field on marketo lead (?<email>.+@.+..+) should (?<operator>be set|not be set|be less than|be greater than|be one of|be|contain|not be one of|not be|not contain|match|not match) ?(?<expectation>.+)?');
-    expect(stepDef.getType()).to.equal(StepDefinition.Type.VALIDATION);
-  });
-
-  it('should return expected step fields', () => {
-    const stepDef: StepDefinition = stepUnderTest.getDefinition();
-    const fields: any[] = stepDef.getExpectedFieldsList().map((field: FieldDefinition) => {
-      return field.toObject();
+    beforeEach(() => {
+      protoStep = new ProtoStep();
+      clientWrapperStub = sinon.stub();
+      clientWrapperStub.findLeadByField = sinon.stub();
+      stepUnderTest = new Step(clientWrapperStub);
     });
 
-    // Email field
-    expect(fields[0].key).to.equal('email');
-    expect(fields[0].optionality).to.equal(FieldDefinition.Optionality.REQUIRED);
-    expect(fields[0].type).to.equal(FieldDefinition.Type.STRING);
+    it('should return expected step metadata', () => {
+      const stepDef: StepDefinition = stepUnderTest.getDefinition();
+      expect(stepDef.getStepId()).to.equal('LeadFieldEqualsStep');
+      expect(stepDef.getName()).to.equal('Check a field on a Marketo Lead');
+      expect(stepDef.getExpression()).to.equal('the (?<field>[a-zA-Z0-9_-]+) field on marketo lead (?<email>.+@.+..+) should (?<operator>be set|not be set|be less than|be greater than|be one of|be|contain|not be one of|not be|not contain|match|not match) ?(?<expectation>.+)?');
+      expect(stepDef.getType()).to.equal(StepDefinition.Type.VALIDATION);
+    });
 
-    // Field Name field
-    expect(fields[1].key).to.equal('field');
-    expect(fields[1].optionality).to.equal(FieldDefinition.Optionality.REQUIRED);
-    expect(fields[1].type).to.equal(FieldDefinition.Type.STRING);
+    it('should return expected step fields', () => {
+      const stepDef: StepDefinition = stepUnderTest.getDefinition();
+      const fields: any[] = stepDef.getExpectedFieldsList().map((field: FieldDefinition) => {
+        return field.toObject();
+      });
 
-    // Operator field
-    expect(fields[2].key).to.equal('operator');
-    expect(fields[2].optionality).to.equal(FieldDefinition.Optionality.OPTIONAL);
-    expect(fields[2].type).to.equal(FieldDefinition.Type.STRING);
+      // Email field
+      expect(fields[0].key).to.equal('email');
+      expect(fields[0].optionality).to.equal(FieldDefinition.Optionality.REQUIRED);
+      expect(fields[0].type).to.equal(FieldDefinition.Type.STRING);
 
-    // Expectation field
-    expect(fields[3].key).to.equal('expectation');
-    expect(fields[3].optionality).to.equal(FieldDefinition.Optionality.OPTIONAL);
-    expect(fields[3].type).to.equal(FieldDefinition.Type.ANYSCALAR);
+      // Field Name field
+      expect(fields[1].key).to.equal('field');
+      expect(fields[1].optionality).to.equal(FieldDefinition.Optionality.REQUIRED);
+      expect(fields[1].type).to.equal(FieldDefinition.Type.STRING);
 
-    // Partition ID field
-    expect(fields[4].key).to.equal('partitionId');
-    expect(fields[4].optionality).to.equal(FieldDefinition.Optionality.OPTIONAL);
-    expect(fields[4].type).to.equal(FieldDefinition.Type.NUMERIC);
+      // Operator field
+      expect(fields[2].key).to.equal('operator');
+      expect(fields[2].optionality).to.equal(FieldDefinition.Optionality.OPTIONAL);
+      expect(fields[2].type).to.equal(FieldDefinition.Type.STRING);
+
+      // Expectation field
+      expect(fields[3].key).to.equal('expectation');
+      expect(fields[3].optionality).to.equal(FieldDefinition.Optionality.OPTIONAL);
+      expect(fields[3].type).to.equal(FieldDefinition.Type.ANYSCALAR);
+
+      // Partition ID field
+      expect(fields[4].key).to.equal('partitionId');
+      expect(fields[4].optionality).to.equal(FieldDefinition.Optionality.OPTIONAL);
+      expect(fields[4].type).to.equal(FieldDefinition.Type.NUMERIC);
+    });
+
+    it('should call the client wrapper with the expected args', async () => {
+      const expectedField: string = 'firstName';
+      const expectedEmail: string = 'expected@example.com';
+      const expectedPartitionId: number = 3;
+      protoStep.setData(Struct.fromJavaScript({
+        email: expectedEmail,
+        field: expectedField,
+        operator: 'be',
+        expectation: expectedEmail,
+        partitionId: expectedPartitionId,
+      }));
+
+      await stepUnderTest.executeStep(protoStep);
+      expect(clientWrapperStub.findLeadByField).to.have.been.calledWith(
+        'email',
+        expectedEmail,
+        sinon.match.any,
+        expectedPartitionId,
+      );
+    });
+
+    it('should respond with an error if the marketo client throws an error', async () => {
+      // Cause the client to throw an error, and execute the step.
+      clientWrapperStub.findLeadByField.throws('any error');
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
+    });
+
+    it('should respond with an error if the marketo client did not find a lead', async () => {
+      // Have the client respond with no leads.
+      clientWrapperStub.findLeadByField.returns(Promise.resolve({
+        success: true,
+        result: [],
+      }));
+
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
+    });
+
+    it('should respond with an error if the lead found does not contain the given field', async () => {
+      protoStep.setData(Struct.fromJavaScript({
+        expectation: 'anything',
+        email: 'anyone@example.com',
+        field: 'firstname',
+      }));
+
+      // Have the client respond with an object not containing the field above.
+      clientWrapperStub.findLeadByField.returns(Promise.resolve({
+        success: true,
+        result: [{
+          firstName: '<-- Notice the case',
+        }],
+      }));
+
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.FAILED);
+    });
+
+    it('should respond with a failure if the field on the lead does not match the expectation', async () => {
+      const expectedValue: string = 'Atoma';
+      protoStep.setData(Struct.fromJavaScript({
+        expectation: expectedValue,
+        email: 'anyone@example.com',
+        field: 'firstName',
+      }));
+
+      // Have the client respond with a valid, but mismatched lead.
+      clientWrapperStub.findLeadByField.returns(Promise.resolve({
+        success: true,
+        result: [{
+          firstName: `Not ${expectedValue}`,
+        }],
+      }));
+
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.FAILED);
+    });
+
+    it('should respond with a pass if the field on the lead matches the expectation', async () => {
+      const expectedValue: string = 'Atoma';
+      protoStep.setData(Struct.fromJavaScript({
+        expectation: expectedValue,
+        email: 'anyone@example.com',
+        field: 'firstName',
+      }));
+
+      // Have the client respond with a valid, but mismatched lead.
+      clientWrapperStub.findLeadByField.returns(Promise.resolve({
+        success: true,
+        result: [{
+          firstName: expectedValue,
+        }],
+      }));
+
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+    });
+
+    it("should respond with a pass if the field on the lead matches the expectation with 'be' operator", async () => {
+      const expectedValue: string = 'Atoma';
+      protoStep.setData(Struct.fromJavaScript({
+        expectation: expectedValue,
+        email: 'anyone@example.com',
+        field: 'firstName',
+        operator: 'be',
+      }));
+
+      // Have the client respond with a valid, but mismatched lead.
+      clientWrapperStub.findLeadByField.returns(Promise.resolve({
+        success: true,
+        result: [{
+          firstName: expectedValue,
+        }],
+      }));
+
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+    });
+
+    it("should respond with a pass if the field on the lead matches the expectation with 'contain' operator", async () => {
+      const expectedValue: string = 'Atoma';
+      protoStep.setData(Struct.fromJavaScript({
+        expectation: expectedValue,
+        email: 'anyone@example.com',
+        field: 'firstName',
+        operator: 'contain',
+      }));
+
+      // Have the client respond with a valid, but mismatched lead.
+      clientWrapperStub.findLeadByField.returns(Promise.resolve({
+        success: true,
+        result: [{
+          firstName: 'AtomaWithExtraLetters',
+        }],
+      }));
+
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+    });
+
+    it("should respond with a pass if the field on the lead satisfies the expectation with number value and 'be greater than' operator", async () => {
+      const expectedValue: string = '5';
+      protoStep.setData(Struct.fromJavaScript({
+        expectation: expectedValue,
+        email: 'anyone@example.com',
+        field: 'someNumberField',
+        operator: 'be greater than',
+      }));
+
+      // Have the client respond with a valid, but mismatched lead.
+      clientWrapperStub.findLeadByField.returns(Promise.resolve({
+        success: true,
+        result: [{
+          firstName: 'someName',
+          someNumberField: '10',
+        }],
+      }));
+
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+    });
+
+    it("should respond with a pass if the field on the lead satisfies the expectation with date value and 'be greater than' operator", async () => {
+      const expectedValue: string = '2000-01-01';
+      protoStep.setData(Struct.fromJavaScript({
+        expectation: expectedValue,
+        email: 'anyone@example.com',
+        field: 'someDateField',
+        operator: 'be greater than',
+      }));
+
+      // Have the client respond with a valid, but mismatched lead.
+      clientWrapperStub.findLeadByField.returns(Promise.resolve({
+        success: true,
+        result: [{
+          firstName: 'someName',
+          someDateField: '2000-02-01',
+        }],
+      }));
+
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+    });
+
+    it("should respond with a pass if the field on the lead matches the expectation with 'not be' operator", async () => {
+      const expectedValue: string = 'Atoma';
+      protoStep.setData(Struct.fromJavaScript({
+        expectation: expectedValue,
+        email: 'anyone@example.com',
+        field: 'firstName',
+        operator: 'not be',
+      }));
+
+      // Have the client respond with a valid, but mismatched lead.
+      clientWrapperStub.findLeadByField.returns(Promise.resolve({
+        success: true,
+        result: [{
+          firstName: 'someOtherValue',
+        }],
+      }));
+
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+    });
+
+    it("should respond with a pass if the field on the lead matches the expectation with 'not contain' operator", async () => {
+      const expectedValue: string = 'Atoma';
+      protoStep.setData(Struct.fromJavaScript({
+        expectation: expectedValue,
+        email: 'anyone@example.com',
+        field: 'firstName',
+        operator: 'not contain',
+      }));
+
+      // Have the client respond with a valid, but mismatched lead.
+      clientWrapperStub.findLeadByField.returns(Promise.resolve({
+        success: true,
+        result: [{
+          firstName: 'Atom',
+        }],
+      }));
+
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+    });
+
+    it("should respond with a pass if the field on the lead satisfies the expectation with number value and 'be less than' operator", async () => {
+      const expectedValue: string = '10';
+      protoStep.setData(Struct.fromJavaScript({
+        expectation: expectedValue,
+        email: 'anyone@example.com',
+        field: 'someNumberField',
+        operator: 'be less than',
+      }));
+
+      // Have the client respond with a valid, but mismatched lead.
+      clientWrapperStub.findLeadByField.returns(Promise.resolve({
+        success: true,
+        result: [{
+          firstName: 'someName',
+          someNumberField: '5',
+        }],
+      }));
+
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+    });
+
+    it("should respond with a pass if the field on the lead satisfies the expectation with date value and 'be less than' operator", async () => {
+      const expectedValue: string = '2000-02-01';
+      protoStep.setData(Struct.fromJavaScript({
+        expectation: expectedValue,
+        email: 'anyone@example.com',
+        field: 'someDateField',
+        operator: 'be less than',
+      }));
+
+      // Have the client respond with a valid, but mismatched lead.
+      clientWrapperStub.findLeadByField.returns(Promise.resolve({
+        success: true,
+        result: [{
+          firstName: 'someName',
+          someDateField: '2000-01-01',
+        }],
+      }));
+
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+    });
+
+    it("should respond with an error if the field on the lead is not a date or number and 'be less than' operator", async () => {
+      const expectedValue: string = 'notANumber';
+      protoStep.setData(Struct.fromJavaScript({
+        expectation: expectedValue,
+        email: 'anyone@example.com',
+        field: 'someDateField',
+        operator: 'be less than',
+      }));
+
+      // Have the client respond with a valid, but mismatched lead.
+      clientWrapperStub.findLeadByField.returns(Promise.resolve({
+        success: true,
+        result: [{
+          firstName: 'someName',
+          someDateField: '2000-01-01',
+        }],
+      }));
+
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
+    });
+
+    it("should respond with an error if the field on the lead is not a date or number and 'be greater than' operator", async () => {
+      const expectedValue: string = 'notANumber';
+      protoStep.setData(Struct.fromJavaScript({
+        expectation: expectedValue,
+        email: 'anyone@example.com',
+        field: 'someDateField',
+        operator: 'be greater than',
+      }));
+
+      // Have the client respond with a valid, but mismatched lead.
+      clientWrapperStub.findLeadByField.returns(Promise.resolve({
+        success: true,
+        result: [{
+          firstName: 'someName',
+          someDateField: '2000-01-01',
+        }],
+      }));
+
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
+    });
+
+    it('should respond with an error if the operator is invalid', async () => {
+      const expectedValue: string = '12345';
+      protoStep.setData(Struct.fromJavaScript({
+        expectation: expectedValue,
+        email: 'anyone@example.com',
+        field: 'someDateField',
+        operator: 'someOtherOperator',
+      }));
+
+      // Have the client respond with a valid, but mismatched lead.
+      clientWrapperStub.findLeadByField.returns(Promise.resolve({
+        success: true,
+        result: [{
+          firstName: 'someName',
+          someDateField: '2000-01-01',
+        }],
+      }));
+
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
+    });
+
+    it('should respond with error when expectedValue is not passed and operators are not either "be set" or "not be set"', async () => {
+      protoStep.setData(Struct.fromJavaScript({
+        email: 'anyone@example.com',
+        field: 'someDateField',
+        operator: 'be',
+      }));
+
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
+    });
   });
-
-  it('should call the client wrapper with the expected args', async () => {
-    const expectedField: string = 'firstName';
-    const expectedEmail: string = 'expected@example.com';
-    const expectedPartitionId: number = 3;
-    protoStep.setData(Struct.fromJavaScript({
-      email: expectedEmail,
-      field: expectedField,
-      operator: 'be',
-      expectation: expectedEmail,
-      partitionId: expectedPartitionId,
-    }));
-
-    await stepUnderTest.executeStep(protoStep);
-    expect(clientWrapperStub.findLeadByField).to.have.been.calledWith(
-      'email',
-      expectedEmail,
-      sinon.match.any,
-      expectedPartitionId,
-    );
-  });
-
-  it('should respond with an error if the marketo client throws an error', async () => {
-    // Cause the client to throw an error, and execute the step.
-    clientWrapperStub.findLeadByField.throws('any error');
-    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
-    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
-  });
-
-  it('should respond with an error if the marketo client did not find a lead', async () => {
-    // Have the client respond with no leads.
-    clientWrapperStub.findLeadByField.returns(Promise.resolve({
-      success: true,
-      result: [],
-    }));
-
-    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
-    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
-  });
-
-  it('should respond with an error if the lead found does not contain the given field', async () => {
-    protoStep.setData(Struct.fromJavaScript({
-      expectation: 'anything',
-      email: 'anyone@example.com',
-      field: 'firstname',
-    }));
-
-    // Have the client respond with an object not containing the field above.
-    clientWrapperStub.findLeadByField.returns(Promise.resolve({
-      success: true,
-      result: [{
-        firstName: '<-- Notice the case',
-      }],
-    }));
-
-    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
-    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.FAILED);
-  });
-
-  it('should respond with a failure if the field on the lead does not match the expectation', async () => {
-    const expectedValue: string = 'Atoma';
-    protoStep.setData(Struct.fromJavaScript({
-      expectation: expectedValue,
-      email: 'anyone@example.com',
-      field: 'firstName',
-    }));
-
-    // Have the client respond with a valid, but mismatched lead.
-    clientWrapperStub.findLeadByField.returns(Promise.resolve({
-      success: true,
-      result: [{
-        firstName: `Not ${expectedValue}`,
-      }],
-    }));
-
-    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
-    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.FAILED);
-  });
-
-  it('should respond with a pass if the field on the lead matches the expectation', async () => {
-    const expectedValue: string = 'Atoma';
-    protoStep.setData(Struct.fromJavaScript({
-      expectation: expectedValue,
-      email: 'anyone@example.com',
-      field: 'firstName',
-    }));
-
-    // Have the client respond with a valid, but mismatched lead.
-    clientWrapperStub.findLeadByField.returns(Promise.resolve({
-      success: true,
-      result: [{
-        firstName: expectedValue,
-      }],
-    }));
-
-    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
-    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
-  });
-
-  it("should respond with a pass if the field on the lead matches the expectation with 'be' operator", async () => {
-    const expectedValue: string = 'Atoma';
-    protoStep.setData(Struct.fromJavaScript({
-      expectation: expectedValue,
-      email: 'anyone@example.com',
-      field: 'firstName',
-      operator: 'be',
-    }));
-
-    // Have the client respond with a valid, but mismatched lead.
-    clientWrapperStub.findLeadByField.returns(Promise.resolve({
-      success: true,
-      result: [{
-        firstName: expectedValue,
-      }],
-    }));
-
-    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
-    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
-  });
-
-  it("should respond with a pass if the field on the lead matches the expectation with 'contain' operator", async () => {
-    const expectedValue: string = 'Atoma';
-    protoStep.setData(Struct.fromJavaScript({
-      expectation: expectedValue,
-      email: 'anyone@example.com',
-      field: 'firstName',
-      operator: 'contain',
-    }));
-
-    // Have the client respond with a valid, but mismatched lead.
-    clientWrapperStub.findLeadByField.returns(Promise.resolve({
-      success: true,
-      result: [{
-        firstName: 'AtomaWithExtraLetters',
-      }],
-    }));
-
-    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
-    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
-  });
-
-  it("should respond with a pass if the field on the lead satisfies the expectation with number value and 'be greater than' operator", async () => {
-    const expectedValue: string = '5';
-    protoStep.setData(Struct.fromJavaScript({
-      expectation: expectedValue,
-      email: 'anyone@example.com',
-      field: 'someNumberField',
-      operator: 'be greater than',
-    }));
-
-    // Have the client respond with a valid, but mismatched lead.
-    clientWrapperStub.findLeadByField.returns(Promise.resolve({
-      success: true,
-      result: [{
-        firstName: 'someName',
-        someNumberField: '10',
-      }],
-    }));
-
-    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
-    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
-  });
-
-  it("should respond with a pass if the field on the lead satisfies the expectation with date value and 'be greater than' operator", async () => {
-    const expectedValue: string = '2000-01-01';
-    protoStep.setData(Struct.fromJavaScript({
-      expectation: expectedValue,
-      email: 'anyone@example.com',
-      field: 'someDateField',
-      operator: 'be greater than',
-    }));
-
-    // Have the client respond with a valid, but mismatched lead.
-    clientWrapperStub.findLeadByField.returns(Promise.resolve({
-      success: true,
-      result: [{
-        firstName: 'someName',
-        someDateField: '2000-02-01',
-      }],
-    }));
-
-    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
-    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
-  });
-
-  it("should respond with a pass if the field on the lead matches the expectation with 'not be' operator", async () => {
-    const expectedValue: string = 'Atoma';
-    protoStep.setData(Struct.fromJavaScript({
-      expectation: expectedValue,
-      email: 'anyone@example.com',
-      field: 'firstName',
-      operator: 'not be',
-    }));
-
-    // Have the client respond with a valid, but mismatched lead.
-    clientWrapperStub.findLeadByField.returns(Promise.resolve({
-      success: true,
-      result: [{
-        firstName: 'someOtherValue',
-      }],
-    }));
-
-    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
-    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
-  });
-
-  it("should respond with a pass if the field on the lead matches the expectation with 'not contain' operator", async () => {
-    const expectedValue: string = 'Atoma';
-    protoStep.setData(Struct.fromJavaScript({
-      expectation: expectedValue,
-      email: 'anyone@example.com',
-      field: 'firstName',
-      operator: 'not contain',
-    }));
-
-    // Have the client respond with a valid, but mismatched lead.
-    clientWrapperStub.findLeadByField.returns(Promise.resolve({
-      success: true,
-      result: [{
-        firstName: 'Atom',
-      }],
-    }));
-
-    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
-    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
-  });
-
-  it("should respond with a pass if the field on the lead satisfies the expectation with number value and 'be less than' operator", async () => {
-    const expectedValue: string = '10';
-    protoStep.setData(Struct.fromJavaScript({
-      expectation: expectedValue,
-      email: 'anyone@example.com',
-      field: 'someNumberField',
-      operator: 'be less than',
-    }));
-
-    // Have the client respond with a valid, but mismatched lead.
-    clientWrapperStub.findLeadByField.returns(Promise.resolve({
-      success: true,
-      result: [{
-        firstName: 'someName',
-        someNumberField: '5',
-      }],
-    }));
-
-    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
-    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
-  });
-
-  it("should respond with a pass if the field on the lead satisfies the expectation with date value and 'be less than' operator", async () => {
-    const expectedValue: string = '2000-02-01';
-    protoStep.setData(Struct.fromJavaScript({
-      expectation: expectedValue,
-      email: 'anyone@example.com',
-      field: 'someDateField',
-      operator: 'be less than',
-    }));
-
-    // Have the client respond with a valid, but mismatched lead.
-    clientWrapperStub.findLeadByField.returns(Promise.resolve({
-      success: true,
-      result: [{
-        firstName: 'someName',
-        someDateField: '2000-01-01',
-      }],
-    }));
-
-    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
-    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
-  });
-
-  it("should respond with an error if the field on the lead is not a date or number and 'be less than' operator", async () => {
-    const expectedValue: string = 'notANumber';
-    protoStep.setData(Struct.fromJavaScript({
-      expectation: expectedValue,
-      email: 'anyone@example.com',
-      field: 'someDateField',
-      operator: 'be less than',
-    }));
-
-    // Have the client respond with a valid, but mismatched lead.
-    clientWrapperStub.findLeadByField.returns(Promise.resolve({
-      success: true,
-      result: [{
-        firstName: 'someName',
-        someDateField: '2000-01-01',
-      }],
-    }));
-
-    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
-    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
-  });
-
-  it("should respond with an error if the field on the lead is not a date or number and 'be greater than' operator", async () => {
-    const expectedValue: string = 'notANumber';
-    protoStep.setData(Struct.fromJavaScript({
-      expectation: expectedValue,
-      email: 'anyone@example.com',
-      field: 'someDateField',
-      operator: 'be greater than',
-    }));
-
-    // Have the client respond with a valid, but mismatched lead.
-    clientWrapperStub.findLeadByField.returns(Promise.resolve({
-      success: true,
-      result: [{
-        firstName: 'someName',
-        someDateField: '2000-01-01',
-      }],
-    }));
-
-    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
-    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
-  });
-
-  it('should respond with an error if the operator is invalid', async () => {
-    const expectedValue: string = '12345';
-    protoStep.setData(Struct.fromJavaScript({
-      expectation: expectedValue,
-      email: 'anyone@example.com',
-      field: 'someDateField',
-      operator: 'someOtherOperator',
-    }));
-
-    // Have the client respond with a valid, but mismatched lead.
-    clientWrapperStub.findLeadByField.returns(Promise.resolve({
-      success: true,
-      result: [{
-        firstName: 'someName',
-        someDateField: '2000-01-01',
-      }],
-    }));
-
-    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
-    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
-  });
-
-  it('should respond with error when expectedValue is not passed and operators are not either "be set" or "not be set"', async () => {
-    protoStep.setData(Struct.fromJavaScript({
-      email: 'anyone@example.com',
-      field: 'someDateField',
-      operator: 'be',
-    }));
-
-    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
-    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
+  
+  describe('Bulk Lead Check', () => {
+    beforeEach(() => {
+      protoStep = new ProtoStep();
+      clientWrapperStub = sinon.stub();
+      clientWrapperStub.bulkFindLeadsByEmail = sinon.stub();
+      stepUnderTest = new Step(clientWrapperStub);
+    });
+  
+    it('should respond with an error if the marketo client throws an error', async () => {
+      protoStep.setData(Struct.fromJavaScript({
+        email: 'dummyEmail',
+        multiple_email: ['test@thisisjust.atomatest.com', 'test2@thisisjust.atomatest.com'],
+        expectation: 'anything',
+        field: 'firstname',
+      }));
+      // Cause the client to throw an error, and execute the step.
+      clientWrapperStub.bulkFindLeadsByEmail.throws('any error');
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
+    });
+  
+    it('should respond with an error if the marketo client did not find a lead', async () => {
+      protoStep.setData(Struct.fromJavaScript({
+        email: 'dummyEmail',
+        multiple_email: ['test@thisisjust.atomatest.com', 'test2@thisisjust.atomatest.com'],
+        expectation: 'anything',
+        field: 'firstname',
+      }));
+  
+      // Have the client respond with no leads.
+      clientWrapperStub.bulkFindLeadsByEmail.returns(Promise.resolve({
+        success: true,
+        result: [],
+      }));
+  
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
+    });
+  
+    it('should respond with an error if the lead found does not contain the given field', async () => {
+      protoStep.setData(Struct.fromJavaScript({
+        email: 'dummyEmail',
+        multiple_email: ['test@thisisjust.atomatest.com', 'test2@thisisjust.atomatest.com'],
+        expectation: 'anything',
+        field: 'firstname',
+      }));
+  
+      // Have the client respond with an object not containing the field above.
+      clientWrapperStub.bulkFindLeadsByEmail.returns(Promise.resolve([{
+        success: true,
+        result: [{
+          firstName: '<-- Notice the case',
+          id: 1,
+          email: 'expected1@example.com',
+        }, {
+          firstName: '<-- Notice the case',
+          id: 2,
+          email: 'expected2@example.com',
+        }, {
+          firstName: '<-- Notice the case',
+          id: 3,
+          email: 'expected3@example.com',
+        }],
+      }]));
+  
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.FAILED);
+    });
+    
+    it('should respond with a failure if the number of leads does not match the number of expectations', async () => {
+      const expectedValue: string = 'Atoma';
+      protoStep.setData(Struct.fromJavaScript({
+        expectation: expectedValue,
+        email: 'dummyEmail',
+        multiple_email: ['test@thisisjust.atomatest.com', 'test2@thisisjust.atomatest.com'],
+        multiple_expectation: ['expectation1', 'expectation2', 'expectation3'],
+        field: 'firstName',
+      }));
+  
+      // Have the client respond with a valid, but mismatched lead.
+      clientWrapperStub.bulkFindLeadsByEmail.returns(Promise.resolve([{
+        success: true,
+        result: [{
+          firstName: 'not expected value',
+          id: 1,
+          email: 'expected1@example.com',
+        }, {
+          firstName: 'not expected value',
+          id: 2,
+          email: 'expected2@example.com',
+        }, {
+          firstName: 'not expected value',
+          id: 3,
+          email: 'expected3@example.com',
+        }],
+      }]));
+  
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.FAILED);
+      expect(response.toObject().messageFormat).to.contain('Number of leads provided did not match number of expected values provided');
+    });
+  
+    it('should respond with a failure if the field on the lead does not match the expectation', async () => {
+      const expectedValue: string = 'Atoma';
+      protoStep.setData(Struct.fromJavaScript({
+        expectation: expectedValue,
+        email: 'dummyEmail',
+        multiple_email: ['test@thisisjust.atomatest.com', 'test2@thisisjust.atomatest.com'],
+        field: 'firstName',
+      }));
+  
+      // Have the client respond with a valid, but mismatched lead.
+      clientWrapperStub.bulkFindLeadsByEmail.returns(Promise.resolve([{
+        success: true,
+        result: [{
+          firstName: 'not expected value',
+          id: 1,
+          email: 'expected1@example.com',
+        }, {
+          firstName: 'not expected value',
+          id: 2,
+          email: 'expected2@example.com',
+        }, {
+          firstName: 'not expected value',
+          id: 3,
+          email: 'expected3@example.com',
+        }],
+      }]));
+  
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.FAILED);
+      expect(response.toObject().messageFormat).to.contain('Found %d of %d leads where the %s field was found to %s %s');
+    });
+  
+    it('should respond with a pass if the field on the lead matches the expectation', async () => {
+      protoStep.setData(Struct.fromJavaScript({
+        expectation: 'Atoma',
+        email: 'dummyEmail',
+        multiple_email: ['expected1@example.com', 'expected2@example.com', 'expected3@example.com'],
+        field: 'firstName',
+      }));
+  
+      // Have the client respond with a valid, but mismatched lead.
+      clientWrapperStub.bulkFindLeadsByEmail.returns(Promise.resolve([{
+        success: true,
+        result: [{
+          firstName: 'Atoma',
+          id: 1,
+          email: 'expected1@example.com',
+        }, {
+          firstName: 'Atoma',
+          id: 2,
+          email: 'expected2@example.com',
+        }, {
+          firstName: 'Atoma',
+          id: 3,
+          email: 'expected3@example.com',
+        }],
+      }]));
+  
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+      expect(response.toObject().messageFormat).to.contain('Successfully checked %d leads');
+    });
+    
+    it('should respond with a pass if the fields on all leads match dynamic expectations', async () => {
+      protoStep.setData(Struct.fromJavaScript({
+        expectation: 'Atoma',
+        email: 'dummyEmail',
+        multiple_email: ['expected1@example.com', 'expected2@example.com', 'expected3@example.com'],
+        multiple_expectation: ['expectation1', 'expectation2', 'expectation3'],
+        field: 'firstName',
+      }));
+  
+      // Have the client respond with a valid, but mismatched lead.
+      clientWrapperStub.bulkFindLeadsByEmail.returns(Promise.resolve([{
+        success: true,
+        result: [{
+          firstName: 'expectation1',
+          id: 1,
+          email: 'expected1@example.com',
+        }, {
+          firstName: 'expectation2',
+          id: 2,
+          email: 'expected2@example.com',
+        }, {
+          firstName: 'expectation3',
+          id: 3,
+          email: 'expected3@example.com',
+        }],
+      }]));
+  
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+      expect(response.toObject().messageFormat).to.contain('Successfully checked %d leads');
+    });
+  
+    it("should respond with a pass if the field on the lead matches the expectation with 'be' operator", async () => {
+      const expectedValue: string = 'Atoma';
+      protoStep.setData(Struct.fromJavaScript({
+        expectation: expectedValue,
+        email: 'dummyEmail',
+        multiple_email: ['expected1@example.com', 'expected2@example.com', 'expected3@example.com'],
+        field: 'firstName',
+        operator: 'be',
+      }));
+  
+      // Have the client respond with a valid, but mismatched lead.
+      clientWrapperStub.bulkFindLeadsByEmail.returns(Promise.resolve([{
+        success: true,
+        result: [{
+          firstName: expectedValue,
+          id: 1,
+          email: 'expected1@example.com',
+        }, {
+          firstName: expectedValue,
+          id: 2,
+          email: 'expected2@example.com',
+        }, {
+          firstName: expectedValue,
+          id: 3,
+          email: 'expected3@example.com',
+        }],
+      }]));
+  
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+      expect(response.toObject().messageFormat).to.contain('Successfully checked %d leads');
+    });
+  
+    it("should respond with a pass if the field on the lead matches the expectation with 'contain' operator", async () => {
+      const expectedValue: string = 'Atoma';
+      protoStep.setData(Struct.fromJavaScript({
+        expectation: expectedValue,
+        email: 'dummyEmail',
+        multiple_email: ['expected1@example.com', 'expected2@example.com', 'expected3@example.com'],
+        field: 'firstName',
+        operator: 'contain',
+      }));
+  
+      // Have the client respond with a valid, but mismatched lead.
+      clientWrapperStub.bulkFindLeadsByEmail.returns(Promise.resolve([{
+        success: true,
+        result: [{
+          firstName: 'Atomawithextraletters',
+          id: 1,
+          email: 'expected1@example.com',
+        }, {
+          firstName: 'Atomawithextraletters',
+          id: 2,
+          email: 'expected2@example.com',
+        }, {
+          firstName: 'Atomawithextraletters',
+          id: 3,
+          email: 'expected3@example.com',
+        }],
+      }]));
+  
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+      expect(response.toObject().messageFormat).to.contain('Successfully checked %d leads');
+    });
+  
+    it("should respond with a pass if the field on the lead satisfies the expectation with number value and 'be greater than' operator", async () => {
+      const expectedValue: string = '5';
+      protoStep.setData(Struct.fromJavaScript({
+        expectation: expectedValue,
+        email: 'dummyEmail',
+        multiple_email: ['expected1@example.com', 'expected2@example.com', 'expected3@example.com'],
+        field: 'someNumberField',
+        operator: 'be greater than',
+      }));
+  
+      // Have the client respond with a valid, but mismatched lead.
+      clientWrapperStub.bulkFindLeadsByEmail.returns(Promise.resolve([{
+        success: true,
+        result: [{
+          someNumberField: 10,
+          id: 1,
+          email: 'expected1@example.com',
+        }, {
+          someNumberField: 10,
+          id: 2,
+          email: 'expected2@example.com',
+        }, {
+          someNumberField: 10,
+          id: 3,
+          email: 'expected3@example.com',
+        }],
+      }]));
+  
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+      expect(response.toObject().messageFormat).to.contain('Successfully checked %d leads');
+    });
+  
+    it("should respond with a pass if the field on the lead satisfies the expectation with date value and 'be greater than' operator", async () => {
+      const expectedValue: string = '2000-01-01';
+      protoStep.setData(Struct.fromJavaScript({
+        expectation: expectedValue,
+        email: 'dummyEmail',
+        multiple_email: ['expected1@example.com', 'expected2@example.com', 'expected3@example.com'],
+        field: 'someDateField',
+        operator: 'be greater than',
+      }));
+  
+      // Have the client respond with a valid, but mismatched lead.
+      clientWrapperStub.bulkFindLeadsByEmail.returns(Promise.resolve([{
+        success: true,
+        result: [{
+          someDateField: '2000-02-02',
+          id: 1,
+          email: 'expected1@example.com',
+        }, {
+          someDateField: '2000-02-02',
+          id: 2,
+          email: 'expected2@example.com',
+        }, {
+          someDateField: '2000-02-02',
+          id: 3,
+          email: 'expected3@example.com',
+        }],
+      }]));
+  
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+      expect(response.toObject().messageFormat).to.contain('Successfully checked %d leads');
+    });
+  
+    it("should respond with a pass if the field on the lead matches the expectation with 'not be' operator", async () => {
+      const expectedValue: string = 'Atoma';
+      protoStep.setData(Struct.fromJavaScript({
+        expectation: expectedValue,
+        email: 'dummyEmail',
+        multiple_email: ['expected1@example.com', 'expected2@example.com', 'expected3@example.com'],
+        field: 'firstName',
+        operator: 'not be',
+      }));
+  
+      // Have the client respond with a valid, but mismatched lead.
+      clientWrapperStub.bulkFindLeadsByEmail.returns(Promise.resolve([{
+        success: true,
+        result: [{
+          firstName: 'Someothername',
+          id: 1,
+          email: 'expected1@example.com',
+        }, {
+          firstName: 'Someothername',
+          id: 2,
+          email: 'expected2@example.com',
+        }, {
+          firstName: 'Someothername',
+          id: 3,
+          email: 'expected3@example.com',
+        }],
+      }]));
+  
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+      expect(response.toObject().messageFormat).to.contain('Successfully checked %d leads');
+    });
+  
+    it("should respond with a pass if the field on the lead matches the expectation with 'not contain' operator", async () => {
+      const expectedValue: string = 'Atoma';
+      protoStep.setData(Struct.fromJavaScript({
+        expectation: expectedValue,
+        email: 'dummyEmail',
+        multiple_email: ['expected1@example.com', 'expected2@example.com', 'expected3@example.com'],
+        field: 'firstName',
+        operator: 'not contain',
+      }));
+  
+      // Have the client respond with a valid, but mismatched lead.
+      clientWrapperStub.bulkFindLeadsByEmail.returns(Promise.resolve([{
+        success: true,
+        result: [{
+          firstName: 'Atom',
+          id: 1,
+          email: 'expected1@example.com',
+        }, {
+          firstName: 'Atom',
+          id: 2,
+          email: 'expected2@example.com',
+        }, {
+          firstName: 'Atom',
+          id: 3,
+          email: 'expected3@example.com',
+        }],
+      }]));
+  
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+      expect(response.toObject().messageFormat).to.contain('Successfully checked %d leads');
+    });
+  
+    it("should respond with a pass if the field on the lead satisfies the expectation with number value and 'be less than' operator", async () => {
+      const expectedValue: string = '10';
+      protoStep.setData(Struct.fromJavaScript({
+        expectation: expectedValue,
+        email: 'dummyEmail',
+        multiple_email: ['expected1@example.com', 'expected2@example.com', 'expected3@example.com'],
+        field: 'someNumberField',
+        operator: 'be less than',
+      }));
+  
+      // Have the client respond with a valid, but mismatched lead.
+      clientWrapperStub.bulkFindLeadsByEmail.returns(Promise.resolve([{
+        success: true,
+        result: [{
+          firstName: 'Atom',
+          id: 1,
+          email: 'expected1@example.com',
+          someNumberField: 5,
+        }, {
+          firstName: 'Atom',
+          id: 2,
+          email: 'expected2@example.com',
+          someNumberField: 5,
+        }, {
+          firstName: 'Atom',
+          id: 3,
+          email: 'expected3@example.com',
+          someNumberField: 5,
+        }],
+      }]));
+  
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+      expect(response.toObject().messageFormat).to.contain('Successfully checked %d leads');
+    });
+  
+    it("should respond with a pass if the field on the lead satisfies the expectation with date value and 'be less than' operator", async () => {
+      const expectedValue: string = '2000-02-01';
+      protoStep.setData(Struct.fromJavaScript({
+        expectation: expectedValue,
+        email: 'dummyEmail',
+        multiple_email: ['expected1@example.com', 'expected2@example.com', 'expected3@example.com'],
+        field: 'someDateField',
+        operator: 'be less than',
+      }));
+  
+      // Have the client respond with a valid, but mismatched lead.
+      clientWrapperStub.bulkFindLeadsByEmail.returns(Promise.resolve([{
+        success: true,
+        result: [{
+          firstName: 'Atom',
+          id: 1,
+          email: 'expected1@example.com',
+          someDateField: '2000-01-01',
+        }, {
+          firstName: 'Atom',
+          id: 2,
+          email: 'expected2@example.com',
+          someDateField: '2000-01-01',
+        }, {
+          firstName: 'Atom',
+          id: 3,
+          email: 'expected3@example.com',
+          someDateField: '2000-01-01',
+        }],
+      }]));
+  
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+      expect(response.toObject().messageFormat).to.contain('Successfully checked %d leads');
+    });
+  
+    it("should respond with an error if the field on the lead is not a date or number and 'be less than' operator", async () => {
+      const expectedValue: string = 'notANumber';
+      protoStep.setData(Struct.fromJavaScript({
+        expectation: expectedValue,
+        email: 'dummyEmail',
+        multiple_email: ['expected1@example.com', 'expected2@example.com', 'expected3@example.com'],
+        field: 'someDateField',
+        operator: 'be less than',
+      }));
+  
+      // Have the client respond with a valid, but mismatched lead.
+      clientWrapperStub.bulkFindLeadsByEmail.returns(Promise.resolve([{
+        success: true,
+        result: [{
+          firstName: 'Atom',
+          id: 1,
+          email: 'expected1@example.com',
+          someDateField: '2000-01-01',
+        }, {
+          firstName: 'Atom',
+          id: 2,
+          email: 'expected2@example.com',
+          someDateField: '2000-01-01',
+        }, {
+          firstName: 'Atom',
+          id: 3,
+          email: 'expected3@example.com',
+          someDateField: '2000-01-01',
+        }],
+      }]));
+  
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
+    });
+  
+    it("should respond with an error if the field on the lead is not a date or number and 'be greater than' operator", async () => {
+      const expectedValue: string = 'notANumber';
+      protoStep.setData(Struct.fromJavaScript({
+        expectation: expectedValue,
+        email: 'dummyEmail',
+        multiple_email: ['expected1@example.com', 'expected2@example.com', 'expected3@example.com'],
+        field: 'someDateField',
+        operator: 'be greater than',
+      }));
+  
+      // Have the client respond with a valid, but mismatched lead.
+      clientWrapperStub.bulkFindLeadsByEmail.returns(Promise.resolve([{
+        success: true,
+        result: [{
+          firstName: 'Atom',
+          id: 1,
+          email: 'expected1@example.com',
+          someDateField: '2000-01-01',
+        }, {
+          firstName: 'Atom',
+          id: 2,
+          email: 'expected2@example.com',
+          someDateField: '2000-01-01',
+        }, {
+          firstName: 'Atom',
+          id: 3,
+          email: 'expected3@example.com',
+          someDateField: '2000-01-01',
+        }],
+      }]));
+  
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
+    });
+  
+    it('should respond with an error if the operator is invalid', async () => {
+      const expectedValue: string = '12345';
+      protoStep.setData(Struct.fromJavaScript({
+        expectation: expectedValue,
+        email: 'dummyEmail',
+        multiple_email: ['expected1@example.com', 'expected2@example.com', 'expected3@example.com'],
+        field: 'someDateField',
+        operator: 'someOtherOperator',
+      }));
+  
+      // Have the client respond with a valid, but mismatched lead.
+      clientWrapperStub.bulkFindLeadsByEmail.returns(Promise.resolve([{
+        success: true,
+        result: [{
+          firstName: 'Atom',
+          id: 1,
+          email: 'expected1@example.com',
+          someDateField: '2000-01-01',
+        }, {
+          firstName: 'Atom',
+          id: 2,
+          email: 'expected2@example.com',
+          someDateField: '2000-01-01',
+        }, {
+          firstName: 'Atom',
+          id: 3,
+          email: 'expected3@example.com',
+          someDateField: '2000-01-01',
+        }],
+      }]));
+  
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
+    });
+  
+    it('should respond with error when expectedValue is not passed and operators are not either "be set" or "not be set"', async () => {
+      protoStep.setData(Struct.fromJavaScript({
+        leads: {
+          1: { email: 'expected1@example.com' },
+          2: { email: 'expected2@example.com' },
+          3: { email: 'expected3@example.com' },
+        },
+        field: 'someDateField',
+        operator: 'be',
+      }));
+  
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
+    });
+  
+    it('should respond with an error marketo returns a failure', async () => {
+      const expectedValue: string = '12345';
+      protoStep.setData(Struct.fromJavaScript({
+        expectation: expectedValue,
+        email: 'dummyEmail',
+        multiple_email: ['expected1@example.com', 'expected2@example.com', 'expected3@example.com'],
+        field: 'someDateField',
+        operator: 'someOtherOperator',
+      }));
+  
+      // Have the client respond with a valid, but mismatched lead.
+      clientWrapperStub.bulkFindLeadsByEmail.returns(Promise.resolve([{
+        success: false,
+        result: [{
+          firstName: 'Atom',
+          id: 1,
+          email: 'expected1@example.com',
+          someDateField: '2000-01-01',
+        }, {
+          firstName: 'Atom',
+          id: 2,
+          email: 'expected2@example.com',
+          someDateField: '2000-01-01',
+        }, {
+          firstName: 'Atom',
+          id: 3,
+          email: 'expected3@example.com',
+          someDateField: '2000-01-01',
+        }],
+      }]));
+  
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.FAILED);
+    });
+    
+    
   });
 });


### PR DESCRIPTION
added bulk functionality to check lead activity step
added tests for new bulk functionality on check field equals and check lead activity steps
fixed update lead step bug where email needed to be an update field in order to go through
adjusted the bulk create/update step records to return passedLeads rather than createdLeads and updatedLeads