### PR TITLE
Bulk Create/Update step: fixed pass message on step record

### DIFF
--- a/src/steps/bulk-lead-create-or-update.ts
+++ b/src/steps/bulk-lead-create-or-update.ts
@@ -142,7 +142,7 @@ export class BulkCreateOrUpdateLeadByFieldStep extends BaseStep implements StepI
       } else if (!failedLeadArray.length) {
         records.push(this.createTable('passedLeads', 'Leads Created or Updated', passedLeadArray));
         return this.pass(
-          'Successfully created %d leads and updated %d leads',
+          'Successfully created or updated %d leads',
           [passedLeadArray.length],
           records,
         );


### PR DESCRIPTION
Fixed step record message as it was referencing 2 variables when only one was provided.