### PR TITLE
Bug Fix: Check Marketo Lead Activity By ID Step

### DIFF
--- a/src/steps/check-lead-activity-by-id.ts
+++ b/src/steps/check-lead-activity-by-id.ts
@@ -103,7 +103,7 @@ export class CheckLeadActivityByIdStep extends BaseStep implements StepInterface
       const activities = activityResponse.result;
 
       /* Fail when when the activity supplied is not found in the lead's logs. */
-      if (!activities) {
+      if (!activities.length) {
         return this[includes ? 'fail' : 'pass']('No %s activity found for lead %s within the last %d minute(s)', [
           stepData.activityTypeIdOrName,
           id,

--- a/test/steps/check-lead-activity-by-id.ts
+++ b/test/steps/check-lead-activity-by-id.ts
@@ -137,7 +137,9 @@ describe('CheckLeadActivityByIdStep', () => {
           result: [{ id: 2001, name: 'Lead created' }],
         }));
 
-        clientWrapperStub.getActivitiesByLeadId.returns(Promise.resolve({}));
+        clientWrapperStub.getActivitiesByLeadId.returns(Promise.resolve({
+          result: []
+        }));
       });
 
       it('should respond with fail', async () => {


### PR DESCRIPTION
Needed to be checking the length of the returned array to see if any activities were present, rather than just checking that the array exists.