### PR TITLE
New bulk steps

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build-ts": "tsc",
     "lint": "tslint -c tslint.json -p tsconfig.json",
     "start": "check-engine package.json && node -r ts-node/register src/core/grpc-server.ts",
-    "test": "nyc mocha -r ts-node/register test/*.ts test/**/*.ts --exit",
+    "test": "nyc mocha -r ts-node/register test/*.ts test/**/*.ts test/**/**/*.ts --exit",
     "version": "crank cog:readme automatoninc/marketo && git add README.md"
   },
   "nyc": {

--- a/src/client/caching-client-wrapper.ts
+++ b/src/client/caching-client-wrapper.ts
@@ -4,9 +4,10 @@ class CachingClientWrapper {
   // cachePrefix is scoped to the specific scenario, request, and requestor
   public cachePrefix = `${this.idMap.scenarioId}${this.idMap.requestorId}${this.idMap.connectionId}`;
 
-  constructor(private client: ClientWrapper, public redisClient: any, public idMap: any) {
+  constructor(private client: ClientWrapper, public redisClient: any, public idMap: any, public mailgunCredentials: any) {
     this.redisClient = redisClient;
     this.idMap = idMap;
+    this.mailgunCredentials = mailgunCredentials;
   }
 
   // lead-aware methods
@@ -176,6 +177,11 @@ class CachingClientWrapper {
   public async addLeadToSmartCampaign(campaignId: string, lead: Record<string, any>) {
     await this.clearCache();
     return await this.client.addLeadToSmartCampaign(campaignId, lead);
+  }
+
+  public async bulkAddLeadToSmartCampaign(campaignId: string, leadArray: Number[]) {
+    await this.clearCache();
+    return await this.client.bulkAddLeadToSmartCampaign(campaignId, leadArray);
   }
 
   // static-list-aware methods

--- a/src/client/client-wrapper.ts
+++ b/src/client/client-wrapper.ts
@@ -33,7 +33,7 @@ class ClientWrapper {
   client: Marketo;
   delayInSeconds: number;
 
-  constructor(auth: grpc.Metadata, clientConstructor = Marketo, delayInSeconds = 3) {
+  constructor(auth: grpc.Metadata, clientConstructor = Marketo, delayInSeconds = 3, mailgunCredentials: Record<string, any> = {}) {
     this.client = new clientConstructor({
       endpoint: `${auth.get('endpoint')[0]}/rest`,
       identity: `${auth.get('endpoint')[0]}/identity`,
@@ -42,6 +42,7 @@ class ClientWrapper {
       ...(!!auth.get('partnerId')[0] && { partnerId: auth.get('partnerId')[0] }),
     });
     this.delayInSeconds = delayInSeconds;
+    this.client.mailgunCredentials = mailgunCredentials;
   }
 }
 

--- a/src/client/mixins/smart-campaign-aware.ts
+++ b/src/client/mixins/smart-campaign-aware.ts
@@ -36,7 +36,6 @@ export class SmartCampaignAwareMixin {
             failedLeads[lead.id] = result.errors[0].toString();
           }
         }
-        // passedLeads.push(result); not sure how to map passed leads over, if we should use the og batch, or the result, need to see result format
         resolve(null);
       } catch (e) {
         if (e.code === 200) {

--- a/src/client/mixins/smart-campaign-aware.ts
+++ b/src/client/mixins/smart-campaign-aware.ts
@@ -1,10 +1,102 @@
 import * as Marketo from 'node-marketo-rest';
+import * as mailgun from 'mailgun-js';
 export class SmartCampaignAwareMixin {
   client: Marketo;
   delayInSeconds;
 
   public async addLeadToSmartCampaign(campaignId: string, lead: Record<string, any>) {
-    return this.client.campaign.request(campaignId, [lead]);
+    return await this.client.campaign.request(campaignId, [lead]);
+  }
+
+  public async bulkAddLeadToSmartCampaign(campaignId: string, leadArray: Number[]) {
+    // NOTE: This mixin is overly complex and fragile, but the structure of the API response has limited information, so for now it's the best we can do
+    const leads = leadArray.map((id) => { return { id }; }); // reformatting to match the format expected
+
+    // Maximum of 100 leads allowed per call according to docs, maximum of 3000 leads total (set in the step)
+    const batchSize = 2;
+    const batches = [];
+    for (let i = 0; i < leads.length; i += batchSize) {
+      batches.push(leads.slice(i, i + batchSize));
+    }
+
+    const failedLeads = {}; // key is leadId and value is failure message
+    const passedLeads = []; // array of leadIds
+
+    // Make the API call for each batch
+    await Promise.all(batches.map(batch => new Promise(async (resolve) => {
+      try {
+        // any issue (even with one record) will throw an error, so if we get a value back we know everything succeeded
+        const result = await this.client.campaign.request(campaignId, batch);
+        if (result.success) {
+          passedLeads.push(...batch.map(leadObj => leadObj.id.toString()));
+        } else {
+          // the entire request failed, so all leads in it must have failed
+          for (const lead of batch) {
+            // set error message for each failed lead
+            failedLeads[lead.id] = result.errors[0].toString();
+          }
+        }
+        // passedLeads.push(result); not sure how to map passed leads over, if we should use the og batch, or the result, need to see result format
+        resolve(null);
+      } catch (e) {
+        if (e.code === 200) {
+          // getting a 200 means the request itself went through, but some individual records failed
+
+          const failedInBatch = []; // array of leadIds that failed in this batch, used later to determine which leads passed
+
+          // loop through all the errors in the current batch and group the leads accordingly
+          await e.errors.forEach(async (errorObj) => {
+            // errorObj is structured like this: { code: '1004', message: 'Lead [2307666, 2307667] not found' }
+            // we are assuming that all errors will have an array with lead IDs in the message
+            const leadIdArrayRegex = new RegExp(/\[[\d, ]+\]/); // regex for pulling array out of error message
+
+            // Make sure the error message contains an array with at least one leadId
+            const errContainsLeadIdsArray = leadIdArrayRegex.test(errorObj.message);
+            if (!errContainsLeadIdsArray) {
+              // if it doesn't, we don't know which leads failed, so skip this errorObj for now and send an email so we can investigate further
+              if (this.client.mailgunCredentials.apiKey && this.client.mailgunCredentials.domain && this.client.mailgunCredentials.alertEmail) {
+                const mg = mailgun({ apiKey: this.client.mailgunCredentials.apiKey, domain: this.client.mailgunCredentials.domain });
+                const emailData = {
+                  from: `Marketo Cog <noreply@${this.client.mailgunCredentials.domain}>`,
+                  to: this.client.mailgunCredentials.alertEmail,
+                  subject: 'UNHANDLED ERROR: New error found in Marketo bulkAddLeadToSmartCampaign mixin',
+                  text: `The following is the stringified error object returned by marketo, in which the message property does not have the Lead ID array that we depend on: ${JSON.stringify(errorObj)}`,
+                };
+                mg.messages().send(emailData, (error, body) => {
+                  console.log('email sent: ', body);
+                });
+              }
+
+              return;
+            }
+
+            const failedInCurrError = (errorObj.message.match(leadIdArrayRegex)[0]).slice(1, -1).replace(/ /g, '').split(','); // converting the string version to a real array of Ids
+            failedInBatch.push(...failedInCurrError);
+
+            // loop through the current array of failed lead Ids
+            await failedInCurrError.forEach((leadId) => {
+              // add unique message for each one to the failedLeads object
+              failedLeads[leadId] = errorObj.message.replace(leadIdArrayRegex, leadId);
+            });
+          });
+
+          // any leads in this batch that haven't been added to the failedInBatch array yet must have passed
+          const passedInBatch = batch.map(leadObj => leadObj.id.toString()).filter(id => !failedInBatch.includes(id));
+          passedLeads.push(...passedInBatch);
+
+          resolve(null);
+        } else {
+          // the entire request failed, so all leads in it must have failed
+          for (const lead of batch) {
+            // set error message for each
+            failedLeads[lead.id] = e.toString();
+          }
+          resolve(null);
+        }
+      }
+    })));
+
+    return { passedLeads, failedLeads };
   }
 
   public async getCampaigns() {

--- a/src/client/mixins/smart-campaign-aware.ts
+++ b/src/client/mixins/smart-campaign-aware.ts
@@ -13,7 +13,7 @@ export class SmartCampaignAwareMixin {
     const leads = leadArray.map((id) => { return { id }; }); // reformatting to match the format expected
 
     // Maximum of 100 leads allowed per call according to docs, maximum of 3000 leads total (set in the step)
-    const batchSize = 2;
+    const batchSize = 100;
     const batches = [];
     for (let i = 0; i < leads.length; i += batchSize) {
       batches.push(leads.slice(i, i + batchSize));

--- a/src/core/base-step.ts
+++ b/src/core/base-step.ts
@@ -17,6 +17,7 @@ export interface Field {
   description: string;
   help?: string;
   optionality?: number;
+  bulkSupport?: boolean;
 }
 
 export interface ExpectedRecord {

--- a/src/core/cog.ts
+++ b/src/core/cog.ts
@@ -19,6 +19,7 @@ export class Cog implements ICogServiceServer {
   constructor (private clientWrapperClass, private stepMap: Record<string, any> = {}, private redisUrl: string = undefined, private mailgunCredentials: Record<string, any> = {}) {
     this.steps = [].concat(...Object.values(this.getSteps(`${__dirname}/../steps`, clientWrapperClass)));
     this.redisClient = null;
+    this.mailgunCredentials = mailgunCredentials;
     if (this.redisUrl) {
       const c = redis.createClient(this.redisUrl);
       let emailSent = false;
@@ -197,10 +198,10 @@ export class Cog implements ICogServiceServer {
 
   private getClientWrapper(auth: grpc.Metadata, idMap: {} = null) {
     if (this.redisClient) {
-      const client = new ClientWrapper(auth);
+      const client = new ClientWrapper(auth, undefined, undefined, this.mailgunCredentials);
       return new this.clientWrapperClass(client, this.redisClient, idMap);
     } else {
-      return new ClientWrapper(auth);
+      return new ClientWrapper(auth, undefined, undefined, this.mailgunCredentials);
     }
   }
 }

--- a/src/steps/check-lead-activity.ts
+++ b/src/steps/check-lead-activity.ts
@@ -15,6 +15,7 @@ export class CheckLeadActivityStep extends BaseStep implements StepInterface {
     field: 'email', // to prevent breaking previous scenarios, this is will stay as email
     type: FieldDefinition.Type.STRING,
     description: 'The email address or id of the Marketo Lead',
+    bulkSupport: true,
   }, {
     field: 'activityTypeIdOrName',
     type: FieldDefinition.Type.ANYSCALAR,

--- a/src/steps/check-lead-activity.ts
+++ b/src/steps/check-lead-activity.ts
@@ -138,7 +138,6 @@ export class CheckLeadActivityStep extends BaseStep implements StepInterface {
       if ((stepData.multiple_email && Array.isArray(stepData.multiple_email) && stepData.multiple_email.length > 0) ||
           (stepData.multiple_id && Array.isArray(stepData.multiple_id) && stepData.multiple_id.length > 0)) {
         // Checking multiple leads
-        console.log('multiple leads provided, performing bulk check');
         const leadIds = stepData.multiple_id || [];
         const leadEmails = {};
         const failedArray = [];

--- a/src/steps/lead-field-equals.ts
+++ b/src/steps/lead-field-equals.ts
@@ -16,6 +16,7 @@ export class LeadFieldEqualsStep extends BaseStep implements StepInterface {
     field: 'email', // to prevent breaking previous scenarios, this is will stay as email
     type: FieldDefinition.Type.STRING,
     description: "Lead's email address or id",
+    bulkSupport: true,
   }, {
     field: 'field',
     type: FieldDefinition.Type.STRING,
@@ -30,6 +31,7 @@ export class LeadFieldEqualsStep extends BaseStep implements StepInterface {
     type: FieldDefinition.Type.ANYSCALAR,
     optionality: FieldDefinition.Optionality.OPTIONAL,
     description: 'Expected field value',
+    bulkSupport: true,
   }, {
     field: 'partitionId',
     type: FieldDefinition.Type.NUMERIC,

--- a/src/steps/program-members/program-member-add-or-remove.ts
+++ b/src/steps/program-members/program-member-add-or-remove.ts
@@ -32,6 +32,7 @@ export class AddOrRemoveProgramMemberStep extends BaseStep implements StepInterf
       type: FieldDefinition.Type.STRING,
       optionality: FieldDefinition.Optionality.REQUIRED,
       description: "Lead's email",
+      bulkSupport: true,
     },
   ];
   protected expectedRecords: ExpectedRecord[] = [{

--- a/src/steps/program-members/program-member-add-or-remove.ts
+++ b/src/steps/program-members/program-member-add-or-remove.ts
@@ -1,0 +1,234 @@
+/*tslint:disable:no-else-after-return*/
+
+import { BaseStep, Field, StepInterface, ExpectedRecord } from '../../core/base-step';
+import { Step, FieldDefinition, StepDefinition, RecordDefinition } from '../../proto/cog_pb';
+
+export class AddOrRemoveProgramMemberStep extends BaseStep implements StepInterface {
+
+  protected stepName: string = 'Add or Remove Marketo Program Members';
+  protected stepExpression: string = 'add or remove marketo program members';
+  protected stepType: StepDefinition.Type = StepDefinition.Type.ACTION;
+  protected expectedFields: Field[] = [
+    {
+      field: 'partitionId',
+      type: FieldDefinition.Type.NUMERIC,
+      optionality: FieldDefinition.Optionality.OPTIONAL,
+      description: 'ID of partition the lead will be created',
+    },
+    {
+      field: 'programId',
+      type: FieldDefinition.Type.STRING,
+      optionality: FieldDefinition.Optionality.REQUIRED,
+      description: 'ID of the program',
+    },
+    {
+      field: 'memberStatus',
+      type: FieldDefinition.Type.STRING,
+      optionality: FieldDefinition.Optionality.REQUIRED,
+      description: 'Status to set on the members',
+    },
+    {
+      field: 'email',
+      type: FieldDefinition.Type.STRING,
+      optionality: FieldDefinition.Optionality.REQUIRED,
+      description: "Lead's email",
+    },
+  ];
+  protected expectedRecords: ExpectedRecord[] = [{
+    id: 'passedLeads',
+    type: RecordDefinition.Type.TABLE,
+    fields: [{
+      field: 'id',
+      type: FieldDefinition.Type.NUMERIC,
+      description: 'ID of Marketo Lead',
+    }, {
+      field: 'email',
+      type: FieldDefinition.Type.NUMERIC,
+      description: 'email of Marketo Lead',
+    }, {
+      field: 'status',
+      type: FieldDefinition.Type.STRING,
+      description: 'status of lead',
+    }],
+  }, {
+    id: 'failedLeads',
+    type: RecordDefinition.Type.TABLE,
+    fields: [{
+      field: 'email',
+      type: FieldDefinition.Type.NUMERIC,
+      description: 'email of Marketo Lead',
+    }, {
+      field: 'reasons',
+      type: FieldDefinition.Type.STRING,
+      description: 'Message for explanation of fail',
+    }],
+    dynamicFields: false,
+  }];
+
+  async executeStep(step: Step) {
+    const stepData: any = step.getData().toJavaScript();
+    const partitionId = stepData.partitionId || null;
+    const programId = stepData.programId;
+    const status = stepData.memberStatus;
+    const emailRegex = /(.+)@(.+){2,}\.(.+){2,}/;
+    let leadEmailArray = [];
+
+    if (stepData.multiple_email && Array.isArray(stepData.multiple_email) && stepData.multiple_email.length > 0) {
+      // handle bulk tokens
+
+      // If the user provided emails
+      if (emailRegex.test(stepData.multiple_email[0])) {
+        leadEmailArray = JSON.parse(JSON.stringify(stepData.multiple_email));
+        let count = 0;
+        const bulkFindLeadResponse = await this.client.bulkFindLeadsByEmail(stepData.multiple_email, null, partitionId);
+        await bulkFindLeadResponse.forEach(async (batch) => {
+          if (!batch.success) {
+            return this.error('There was an error finding some lead IDs in partition %d: %s', [partitionId, batch.message]);
+          }
+          count += batch.result.length;
+        });
+
+        if (count !== stepData.multiple_email.length) {
+          return this.error('Could not find all leads provided in partition %d', [partitionId]);
+        }
+
+      } else {
+        // If the user provided IDs rather than emails, we need to get the lead emails now for a few reasons (despite being inefficient):
+        // - that is what the mixins accept, and we can't adjust the mixins wihout also adjusting the other steps that use them
+        // - Marketo's API doesn't return the ID or email for failed records, so we need to know the email in advance so we can return it in the step record
+
+        let count = 0;
+        const bulkFindLeadResponse = await this.client.bulkFindLeadsById(stepData.multiple_email, null, partitionId);
+        await bulkFindLeadResponse.forEach(async (batch) => {
+          if (!batch.success) {
+            return this.error('There was an error finding some leads in partition %d: %s', [partitionId, batch.message]);
+          }
+
+          await batch.result.forEach((lead) => {
+            if (!partitionId || (lead.leadPartitionId && lead.leadPartitionId == partitionId)) {
+              count += 1;
+              leadEmailArray.push(lead.email);
+            }
+          });
+        });
+
+        if (count !== stepData.multiple_email.length) {
+          return this.error('Could not find all leads provided in partition %d', [partitionId]);
+        }
+
+      }
+    } else {
+      // handle single email/ID
+      if (emailRegex.test(stepData.email)) {
+        const response = await this.client.findLeadByEmail(stepData.email, null, partitionId);
+        if (!response.success) {
+          return this.error('There was an error finding lead %d in partition %d', [stepData.email, partitionId]);
+        }
+        leadEmailArray.push(stepData.email);
+      } else {
+        try {
+          const response = await this.client.findLeadByField('id', stepData.email, null, partitionId);
+          const email = response.result[0].email;
+          if (!response.success || !email) {
+            return this.error('There was an error finding lead %d in partition %d', [stepData.email, partitionId]);
+          }
+          leadEmailArray.push(email);
+        } catch (e) {
+          return this.error('There was an error finding lead %d in partition %d', [stepData.email, partitionId]);
+        }
+      }
+    }
+
+    try {
+      const records = [];
+      const passedLeadArray = [];
+      const failedLeadArray = [];
+
+      let data: any = [];
+      if (status === 'Not in Program') {
+        data = await this.client.bulkRemoveLeadsFromProgram(leadEmailArray, programId, partitionId);
+      } else {
+        data = await this.client.bulkSetStatusToLeadsFromProgram(leadEmailArray, programId, status, partitionId);
+      }
+
+      if (data[0] && data[0].error && !data[0].error.partition) {
+        return this.fail('There is no Partition with id %s', [
+          partitionId,
+        ]);
+      }
+
+      // Sort each batch of leads into passed and failed
+      data.forEach((batch, i) => {
+        const startingIndex = i * 300;
+        if (batch.success && batch.result) {
+          batch.result.forEach((result, index) => {
+            const leadArrayIndex = startingIndex + index;
+            if (result.status !== 'skipped') {
+              passedLeadArray.push({ email: leadEmailArray[leadArrayIndex], id: result.leadId, status: result.status });
+            } else if (result.reasons && result.reasons[0]) {
+              failedLeadArray.push({ email: leadEmailArray[leadArrayIndex], message: result.reasons[0].message });
+            } else {
+              failedLeadArray.push({ email: leadEmailArray[leadArrayIndex], message: result.status });
+            }
+          });
+        } else {
+          // if the entire batch failed
+          const failedMembers = leadEmailArray.slice(startingIndex, startingIndex + 300);
+          failedMembers.forEach((leadEmail) => {
+            failedLeadArray.push({ email: leadEmail, message: 'Marketo request failed' });
+          });
+        }
+      });
+
+      const returnedLeadsCount = passedLeadArray.length + failedLeadArray.length;
+
+      if (returnedLeadsCount === 0) {
+        return this.fail('No program members were added or removed in Marketo');
+      }
+
+      if (passedLeadArray.length === returnedLeadsCount) {
+        records.push(this.createTable('passedLeads', `Members ${status === 'Not in Program' ? 'Removed' : 'Added'}`, passedLeadArray));
+        return this.pass(
+          `Successfully ${status === 'Not in Program' ? 'removed' : 'added'} %d members`,
+          [passedLeadArray.length],
+          records,
+        );
+      }
+
+      if (passedLeadArray.length && failedLeadArray.length) {
+        records.push(this.createTable('passedLeads', `Members ${status === 'Not in Program' ? 'Removed' : 'Added'}`, passedLeadArray));
+        records.push(this.createTable('failedLeads', 'Members Failed', failedLeadArray));
+        return this.fail(
+          `${status === 'Not in Program' ? 'Removed' : 'Added'} %d out of %d members`,
+          [passedLeadArray.length, returnedLeadsCount],
+          records,
+        );
+      }
+
+      if (failedLeadArray.length) {
+        records.push(this.createTable('failedLeads', 'Members Failed', failedLeadArray));
+        return this.fail(
+          `Failed to ${status === 'Not in Program' ? 'remove' : 'add'} %d members`,
+          [failedLeadArray.length],
+          records,
+        );
+      }
+
+    } catch (e) {
+      return this.error('There was an error adding or removing members in Marketo: %s', [
+        e.toString(),
+      ]);
+    }
+  }
+
+  private createTable(id, name, leads) {
+    const headers = {};
+    const headerKeys = Object.keys(leads[0] || {});
+    headerKeys.forEach((key: string) => {
+      headers[key] = key;
+    });
+    return this.table(id, name, headers, leads);
+  }
+}
+
+export { AddOrRemoveProgramMemberStep as Step };

--- a/src/steps/smart-campaign-add-lead.ts
+++ b/src/steps/smart-campaign-add-lead.ts
@@ -1,7 +1,7 @@
 /*tslint:disable:no-else-after-return*/
 
 import { BaseStep, Field, StepInterface, ExpectedRecord } from '../core/base-step';
-import { Step, FieldDefinition, StepDefinition, RecordDefinition } from '../proto/cog_pb';
+import { Step, FieldDefinition, StepDefinition, RecordDefinition, StepRecord } from '../proto/cog_pb';
 
 export class AddLeadToSmartCampaignStep extends BaseStep implements StepInterface {
 
@@ -81,6 +81,35 @@ export class AddLeadToSmartCampaignStep extends BaseStep implements StepInterfac
       description: "Campaign's Create Date",
     }],
     dynamicFields: true,
+  }, {
+    id: 'passedLeads',
+    type: RecordDefinition.Type.TABLE,
+    fields: [{
+      field: 'email',
+      type: FieldDefinition.Type.EMAIL,
+      description: 'Email of Marketo Lead (if provided)',
+    }, {
+      field: 'id',
+      type: FieldDefinition.Type.NUMERIC,
+      description: 'ID of Marketo Lead',
+    }],
+  }, {
+    id: 'failedLeads',
+    type: RecordDefinition.Type.TABLE,
+    fields: [{
+      field: 'email',
+      type: FieldDefinition.Type.EMAIL,
+      description: 'Email of Marketo Lead (if provided)',
+    }, {
+      field: 'id',
+      type: FieldDefinition.Type.NUMERIC,
+      description: 'ID of Marketo Lead',
+    }, {
+      field: 'message',
+      type: FieldDefinition.Type.STRING,
+      description: 'Message for explanation of fail',
+    }],
+    dynamicFields: false,
   }];
 
   async executeStep(step: Step) {
@@ -91,54 +120,152 @@ export class AddLeadToSmartCampaignStep extends BaseStep implements StepInterfac
     const isCampaignNameProvided = isNaN(campaignIdOrName);
     let campaignObj: Record<string, any>;
     let campaignRecord;
+    const emailRegex = /(.+)@(.+){2,}\.(.+){2,}/;
+    const allCampaigns = await this.client.getCampaigns();
 
-    try {
-      const allCampaigns = await this.client.getCampaigns();
-      campaignObj = allCampaigns.find(cam => cam.id == campaignIdOrName);
+    if (!allCampaigns.length) {
+      return this.error('Failed to get campaigns from Marketo');
+    }
 
-      if (isCampaignNameProvided) {
-        const matchingCampaigns = allCampaigns.filter(c => c.name ? c.name.toLowerCase() == campaignIdOrName.toLowerCase() : false);
+    campaignObj = allCampaigns.find(cam => cam.id == campaignIdOrName);
 
-        if (matchingCampaigns.length != 1) {
-          return this.error("Can't add %s to %s: found %d matching campaigns", [reference, campaignIdOrName, matchingCampaigns.length]);
+    if (isCampaignNameProvided) {
+      const matchingCampaigns = allCampaigns.filter(c => c.name ? c.name.toLowerCase() == campaignIdOrName.toLowerCase() : false);
+
+      if (matchingCampaigns.length != 1) {
+        return this.error("Can't add lead(s) to %s: found %d matching campaigns", [campaignIdOrName, matchingCampaigns.length]);
+      }
+
+      campaignObj = matchingCampaigns[0];
+    }
+
+    // Adding multiple leads
+    if (stepData.multiple_email && Array.isArray(stepData.multiple_email) && stepData.multiple_email.length > 0) {
+      console.log('found multiple_email, using bulk action')
+
+      stepData.multiple_email = Array.from(new Set(stepData.multiple_email)); // remove any duplicates
+
+      try {
+        if (stepData.multiple_email.length > 3000) {
+          return this.error('Cannot add %d leads, 3000 is the maximum allowed', [stepData.multiple_email.length]);
         }
 
-        campaignObj = matchingCampaigns[0];
-      }
+        let idsArray = [];
+        const idEmailMap = {};
 
-      const emailRegex = /(.+)@(.+){2,}\.(.+){2,}/;
-      let lookupField = 'id';
-      if (emailRegex.test(reference)) {
-        lookupField = 'email';
-      }
+        // If the user provided emails then convert them to IDs
+        if (emailRegex.test(stepData.multiple_email[0])) {
+          const bulkFindLeadResponse = await this.client.bulkFindLeadsByEmail(stepData.multiple_email, null, partitionId);
+          await bulkFindLeadResponse.forEach(async (batch) => {
+            if (!batch.success) {
+              return this.error('There was an error finding some lead IDs in partition %d: %s', [partitionId, batch.message]);
+            }
 
-      const findLeadResponse: any = await this.client.findLeadByField(lookupField, reference, null, partitionId);
+            await batch.result.forEach((lead) => {
+              idsArray.push(lead.id);
+              idEmailMap[lead.id] = lead.email;
+            });
 
-      if (!findLeadResponse.result[0]) {
-        return this.fail(
-          'Couldn\'t find a lead associated with %s%s', [
-            findLeadResponse,
-            partitionId ? ` in partition ${partitionId}` : '',
-          ],
-        );
-      }
+          });
 
-      const leadToBeAdded = findLeadResponse.result[0];
-      const leadRecord = this.keyValue('lead', 'Lead To Be Added', leadToBeAdded);
-      campaignRecord = this.keyValue('campaign', 'Smart Campaign', campaignObj);
+          if (idsArray.length !== stepData.multiple_email.length) {
+            return this.error('Could not find all leads provided in partition %d', [partitionId]);
+          }
 
-      const result = await this.client.addLeadToSmartCampaign(campaignObj.id.toString(), leadToBeAdded);
-      if (result.success) {
-        return this.pass('Successfully added lead %s to smart campaign %s', [reference, campaignIdOrName], [campaignRecord, leadRecord]);
-      } else {
-        return this.fail('Unable to add lead %s to smart campaign %s: %s', [reference, campaignIdOrName, result.message], [campaignRecord, leadRecord]);
+        } else {
+          idsArray = JSON.parse(JSON.stringify(stepData.multiple_email));
+        }
+
+        const bulkResponse = await this.client.bulkAddLeadToSmartCampaign(campaignObj.id.toString(), idsArray);
+        const successArray = []; // contains objects with id and email (if provided)
+        const failArray = []; // contains objects with id, email (if provided), and error message
+
+        // create successArray and failArray from response data
+        if (Object.keys(idEmailMap).length) {
+          for (const leadId of bulkResponse.passedLeads) { // intentionally using for...of loop since passedLeads is an array
+            successArray.push({ id: leadId, email: idEmailMap[leadId] });
+          }
+          for (const leadId in bulkResponse.failedLeads) { // intentionally using for...in loop since failedLeads is an object
+            failArray.push({ id: leadId, email: idEmailMap[leadId], message: bulkResponse.failedLeads[leadId] });
+          }
+        } else {
+          for (const leadId of bulkResponse.passedLeads) {
+            successArray.push({ id: leadId });
+          }
+          for (const leadId in bulkResponse.failedLeads) {
+            failArray.push({ id: leadId, message: bulkResponse.failedLeads[leadId] });
+          }
+        }
+
+        const campaignRecord = this.keyValue('campaign', 'Smart Campaign', campaignObj);
+        const passedLeadRecord = this.createTable('passedLeads', 'Leads Added', successArray);
+        const failedLeadRecord = this.createTable('failedLeads', 'Leads Not Added', failArray);
+
+        if (successArray.length === stepData.multiple_email.length && !failArray.length) {
+          // Every lead passed
+          return this.pass('Successfully added %d leads to smart campaign %s', [successArray.length, campaignIdOrName], [campaignRecord, passedLeadRecord]);
+        } else if (successArray.length && failArray.length) {
+          // Some passed, some failed
+          return this.fail('Successfully added %d out of %d leads to smart campaign %s', [successArray.length, stepData.multiple_email.length, campaignIdOrName], [campaignRecord, passedLeadRecord, failedLeadRecord]);
+        } else if (failArray.length) {
+          // Every lead failed
+          return this.fail('Failed to add %d leads to smart campaign %s', [stepData.multiple_email.length, campaignIdOrName], [campaignRecord, failedLeadRecord]);
+        } else {
+          // Something went wrong
+          return this.error('Error adding leads to smart campaign. Please contact Stack Moxie for help resolving this issue.');
+        }
+
+      } catch (e) {
+        if (e.message.includes("Trigger campaign needs to have a 'Campaign Requested' trigger")) {
+          return this.error("Cannot add lead to smart campaign %s. In order to test this campaign, you must add a 'Campaign is Requested' trigger with 'Source' set to 'Web Service API'", [campaignIdOrName]);
+        }
+        return this.error(e.toString());
       }
-    } catch (e) {
-      if (e.message.includes("Trigger campaign needs to have a 'Campaign Requested' trigger")) {
-        return this.error("Cannot add lead to smart campaign %s. In order to test this campaign, you must add a 'Campaign is Requested' trigger with 'Source' set to 'Web Service API'", [campaignIdOrName]);
+    } else {
+    // Only adding one lead
+      try {
+        let lookupField = 'id';
+        if (emailRegex.test(reference)) {
+          lookupField = 'email';
+        }
+
+        const findLeadResponse: any = await this.client.findLeadByField(lookupField, reference, null, partitionId);
+
+        if (!findLeadResponse.result[0]) {
+          return this.fail(
+            'Couldn\'t find a lead associated with %s%s', [
+              findLeadResponse,
+              partitionId ? ` in partition ${partitionId}` : '',
+            ],
+          );
+        }
+
+        const leadToBeAdded = findLeadResponse.result[0];
+        const leadRecord = this.keyValue('lead', 'Lead To Be Added', leadToBeAdded);
+        campaignRecord = this.keyValue('campaign', 'Smart Campaign', campaignObj);
+
+        const result = await this.client.addLeadToSmartCampaign(campaignObj.id.toString(), leadToBeAdded);
+        if (result.success) {
+          return this.pass('Successfully added lead %s to smart campaign %s', [reference, campaignIdOrName], [campaignRecord, leadRecord]);
+        } else {
+          return this.fail('Unable to add lead %s to smart campaign %s: %s', [reference, campaignIdOrName, result.message], [campaignRecord, leadRecord]);
+        }
+      } catch (e) {
+        if (e.message.includes("Trigger campaign needs to have a 'Campaign Requested' trigger")) {
+          return this.error("Cannot add lead to smart campaign %s. In order to test this campaign, you must add a 'Campaign is Requested' trigger with 'Source' set to 'Web Service API'", [campaignIdOrName]);
+        }
+        return this.error(e.toString());
       }
-      return this.error('%s', [e.toString()]);
     }
+  }
+
+  createTable(id: string, name: string, leads: any[]): StepRecord {
+    const headers = {};
+    const headerKeys = Object.keys(leads[0] || {});
+    headerKeys.forEach((key: string) => {
+      headers[key] = key;
+    });
+    return this.table(id, name, headers, leads);
   }
 
 }

--- a/src/steps/smart-campaign-add-lead.ts
+++ b/src/steps/smart-campaign-add-lead.ts
@@ -12,6 +12,7 @@ export class AddLeadToSmartCampaignStep extends BaseStep implements StepInterfac
     field: 'email',
     type: FieldDefinition.Type.STRING,
     description: "Lead's email address or id",
+    bulkSupport: true,
   }, {
     field: 'campaign',
     type: FieldDefinition.Type.ANYSCALAR,

--- a/src/steps/smart-campaign-add-lead.ts
+++ b/src/steps/smart-campaign-add-lead.ts
@@ -142,7 +142,6 @@ export class AddLeadToSmartCampaignStep extends BaseStep implements StepInterfac
 
     // Adding multiple leads
     if (stepData.multiple_email && Array.isArray(stepData.multiple_email) && stepData.multiple_email.length > 0) {
-      console.log('found multiple_email, using bulk action')
 
       stepData.multiple_email = Array.from(new Set(stepData.multiple_email)); // remove any duplicates
 

--- a/src/steps/static-lists/static-list-add-lead.ts
+++ b/src/steps/static-lists/static-list-add-lead.ts
@@ -16,6 +16,7 @@ export class AddLeadToStaticListStep extends BaseStep implements StepInterface {
     field: 'leadIds',
     type: FieldDefinition.Type.STRING,
     description: 'Ids of Marketo Leads to be added separated by a comma(,) ',
+    bulkSupport: true,
   }];
   protected expectedRecords: ExpectedRecord[] = [{
     id: 'passedLeads',

--- a/src/steps/static-lists/static-list-add-lead.ts
+++ b/src/steps/static-lists/static-list-add-lead.ts
@@ -1,7 +1,7 @@
 /*tslint:disable:no-else-after-return*/
 
 import { BaseStep, Field, StepInterface, ExpectedRecord } from '../../core/base-step';
-import { Step, FieldDefinition, StepDefinition, RecordDefinition } from '../../proto/cog_pb';
+import { Step, FieldDefinition, StepDefinition, RecordDefinition, StepRecord } from '../../proto/cog_pb';
 
 export class AddLeadToStaticListStep extends BaseStep implements StepInterface {
 
@@ -18,55 +18,135 @@ export class AddLeadToStaticListStep extends BaseStep implements StepInterface {
     description: 'Ids of Marketo Leads to be added separated by a comma(,) ',
   }];
   protected expectedRecords: ExpectedRecord[] = [{
-    id: 'staticListAdd',
-    type: RecordDefinition.Type.KEYVALUE,
-    fields: [],
+    id: 'passedLeads',
+    type: RecordDefinition.Type.TABLE,
+    fields: [{
+      field: 'id',
+      type: FieldDefinition.Type.NUMERIC,
+      description: 'ID of Marketo Lead',
+    }, {
+      field: 'status',
+      type: FieldDefinition.Type.STRING,
+      description: 'status of lead',
+    }],
+  }, {
+    id: 'failedLeads',
+    type: RecordDefinition.Type.TABLE,
+    fields: [{
+      field: 'id',
+      type: FieldDefinition.Type.NUMERIC,
+      description: 'ID of Marketo Lead',
+    }, {
+      field: 'status',
+      type: FieldDefinition.Type.STRING,
+      description: 'status of lead',
+    }, {
+      field: 'reasons',
+      type: FieldDefinition.Type.STRING,
+      description: 'Message for explanation of fail',
+    }],
     dynamicFields: false,
   }];
 
   async executeStep(step: Step) {
     const stepData: any = step.getData() ? step.getData().toJavaScript() : {};
     const staticListName = stepData.staticListName;
-    const leadIds = stepData.leadIds;
+    let staticList: any;
+    try {
+      staticList = await this.client.findStaticListsByName(staticListName);
+    } catch (e) {
+      return this.error('Error finding Static List with name %s: %s', [
+        staticListName, JSON.stringify(e),
+      ]);
+    }
+
+    if (!staticList.result || (staticList.result && staticList.result.length === 0)) {
+      return this.error('Static List with name %s does not exist', [
+        staticListName,
+      ]);
+    }
+
+    let leadIds = stepData.leadIds ? stepData.leadIds.replace(' ', '').split(',') : null;
+
+    if (stepData.multiple_leadIds && Array.isArray(stepData.multiple_leadIds) && stepData.multiple_leadIds.length > 0) {
+      leadIds = stepData.multiple_leadIds;
+    }
+
+    leadIds = Array.from(new Set(leadIds)); // remove any duplicates
+
+    if (leadIds.length > 3000) {
+      return this.error('Cannot add %d leads, 3000 is the maximum allowed', [stepData.multiple_leadIds.length]);
+    }
 
     try {
-      // Check if staticList exists and also get the id
-      const staticList: any = await this.client.findStaticListsByName(staticListName);
+      const passedLeads = [];
+      const failedLeads = [];
 
-      if (!staticList.result || (staticList.result && staticList.result.length === 0)) {
-        return this.error('Static List with name %s does not exist', [
-          staticListName,
-        ]);
+      const batchSize = 300; // max amount of leads per request
+      const batches = [];
+      for (let i = 0; i < leadIds.length; i += batchSize) {
+        batches.push(leadIds.slice(i, i + batchSize));
       }
 
-      const data: any = await this.client.addLeadToStaticList(staticList.result[0].id, leadIds.replace(' ', '').split(','));
+      await Promise.all(batches.map(batch => new Promise(async (resolve) => {
+        try {
+          const data: any = await this.client.addLeadToStaticList(staticList.result[0].id, batch);
+          if (!data.success) {
+            // If the batch failed, add each individual lead to failed array
+            await batch.forEach(leadId => failedLeads.push({ id: leadId, status: 'skipped', reasons: `Batch failed with error: ${JSON.stringify(data.errors)}` }));
+          } else {
+            // If the batch passed, add leads to corresponding array
+            await data.result.forEach((l) => {
+              if (l.status === 'added') {
+                passedLeads.push(l);
+              } else {
+                failedLeads.push(l);
+              }
+            });
+          }
+          resolve(null);
+        } catch (e) {
+          // If the batch failed, add each individual lead to failed array
+          await batch.forEach(leadId => failedLeads.push({ id: leadId, status: 'skipped', reasons: `Batch failed with error: ${JSON.stringify(e)}` }));
+        }
+      })));
 
-      if (data.success && data.result.find(l => l.status !== 'added')) {
-        return this.fail('Failed to add all leads to static list %s', [staticListName], [this.createTable(data.result)]);
+      const passedLeadRecord = this.createTable('passedLeads', 'Leads Added', passedLeads);
+      const failedLeadRecord = this.createTable('failedLeads', 'Leads Not Added', failedLeads);
+
+      if (passedLeads.length === leadIds.length && !failedLeads.length) {
+        return this.pass('Successfully added %d leads to static list %s', [passedLeads.length, staticListName], [passedLeadRecord]);
       }
 
-      if (data.success && data.result) {
-        return this.pass('Successfully added leads to static list %s', [staticListName], [this.createTable(data.result)]);
+      if (passedLeads.length && failedLeads.length) {
+        return this.fail('Successfully added %d out of %d leads to static list %s', [passedLeads.length, leadIds.length, staticListName], [passedLeadRecord, failedLeadRecord]);
       }
 
-      return this.error('Failed to add leads to static list %s', [staticListName]);
+      if (failedLeads.length) {
+        return this.fail('Failed to add %d leads to static list %s', [failedLeads.length, staticListName], [failedLeadRecord]);
+      }
+
+      // Something went wrong, we should have returned before this point
+      return this.error('Error adding leads to smart campaign. Please contact Stack Moxie for help resolving this issue.');
     } catch (e) {
-      return this.error('There was an error adding leads to static list %s : %s', [staticListName, e.message]);
+      return this.error('Error adding leads to static list %s: %s', [staticListName, JSON.stringify(e)]);
     }
   }
 
-  createTable(staticListMember: Record<string, any>[]) {
+  createTable(id: string, name: string, leads: any[]): StepRecord {
     const headers = {
       id: 'Id',
       status: 'Status',
-      reasons: 'Reasons',
     };
 
-    staticListMember.forEach((slm, index) => {
-      staticListMember[index]['reasons'] = staticListMember[index]['reasons'] ? JSON.stringify(staticListMember[index]['reasons']) : '-';
-    });
+    if (leads[0] && leads[0]['reasons']) {
+      headers['reasons'] = 'Reasons';
+      leads.forEach((lead, index) => {
+        leads[index]['reasons'] = leads[index]['reasons'] ? JSON.stringify(leads[index]['reasons']) : '-';
+      });
+    }
 
-    return this.table('staticListAdd', 'Static List Members Added', headers, staticListMember);
+    return this.table(id, name, headers, leads);
   }
 }
 

--- a/test/client/caching-client-wrapper.ts
+++ b/test/client/caching-client-wrapper.ts
@@ -50,7 +50,7 @@ describe('CachingClientWrapper', () => {
 
   it('findLeadByEmail using original function', (done) => {
     const expectedEmail = 'test@example.com';
-    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap);
+    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap, null);
     cachingClientWrapperUnderTest.getAsync = sinon.stub().returns(false);
     cachingClientWrapperUnderTest.findLeadByEmail(expectedEmail);
 
@@ -62,7 +62,7 @@ describe('CachingClientWrapper', () => {
 
   it('findLeadByEmail using cache', (done) => {
     const expectedEmail = 'test@example.com';
-    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap);
+    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap, null);
     cachingClientWrapperUnderTest.getAsync = sinon.stub();
     cachingClientWrapperUnderTest.getAsync.returns('"expectedCachedValue"');
     let actualCachedValue: string;
@@ -80,7 +80,7 @@ describe('CachingClientWrapper', () => {
   it('findLeadByField using original function', (done) => {
     const expectedField = 'firstName';
     const expectedId = '123';
-    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap);
+    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap, null);
     cachingClientWrapperUnderTest.getAsync = sinon.stub().returns(false);
     cachingClientWrapperUnderTest.findLeadByField(expectedField, expectedId);
 
@@ -93,7 +93,7 @@ describe('CachingClientWrapper', () => {
   it('findLeadByField using cache', (done) => {
     const expectedField = 'firstName';
     const expectedId = '123';
-    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap);
+    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap, null);
     cachingClientWrapperUnderTest.getAsync = sinon.stub();
     cachingClientWrapperUnderTest.getAsync.returns('"expectedCachedValue"');
     let actualCachedValue: string;
@@ -110,7 +110,7 @@ describe('CachingClientWrapper', () => {
 
   it('createOrUpdateLead', (done) => {
     const expectedLead = { email: 'test@example.com' };
-    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap);
+    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap, null);
     cachingClientWrapperUnderTest.clearCache = sinon.spy();
     cachingClientWrapperUnderTest.createOrUpdateLead(expectedLead);
 
@@ -123,7 +123,7 @@ describe('CachingClientWrapper', () => {
 
   it('deleteLeadById', (done) => {
     const expectedId = 123;
-    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap);
+    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap, null);
     cachingClientWrapperUnderTest.clearCache = sinon.spy();
     cachingClientWrapperUnderTest.deleteLeadById(expectedId);
 
@@ -136,7 +136,7 @@ describe('CachingClientWrapper', () => {
 
   it('describeLeadFields using original function', (done) => {
     const expectedEmail = 'test@example.com';
-    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap);
+    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap, null);
     cachingClientWrapperUnderTest.getAsync = sinon.stub().returns(false);
     cachingClientWrapperUnderTest.describeLeadFields(expectedEmail);
 
@@ -148,7 +148,7 @@ describe('CachingClientWrapper', () => {
 
   it('describeLeadFields using cache', (done) => {
     const expectedEmail = 'test@example.com';
-    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap);
+    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap, null);
     cachingClientWrapperUnderTest.getAsync = sinon.stub();
     cachingClientWrapperUnderTest.getAsync.returns('"expectedCachedValue"');
     let actualCachedValue: string;
@@ -165,7 +165,7 @@ describe('CachingClientWrapper', () => {
 
   it('getCustomObject using original function', (done) => {
     const customObjectName = 'any';
-    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap);
+    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap, null);
     cachingClientWrapperUnderTest.getAsync = sinon.stub().returns(false);
     cachingClientWrapperUnderTest.getCustomObject(customObjectName);
 
@@ -177,7 +177,7 @@ describe('CachingClientWrapper', () => {
 
   it('getCustomObject using cache', (done) => {
     const customObjectName = 'any';
-    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap);
+    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap, null);
     cachingClientWrapperUnderTest.getAsync = sinon.stub();
     cachingClientWrapperUnderTest.getAsync.returns('"expectedCachedValue"');
     let actualCachedValue: string;
@@ -197,7 +197,7 @@ describe('CachingClientWrapper', () => {
     const filterType = 'anyFilterType';
     const searchFields = [{ anySearchField: 'anySearchFieldValue' }];
     const requestFields = ['anyField'];
-    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap);
+    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap, null);
     cachingClientWrapperUnderTest.getAsync = sinon.stub().returns(false);
     cachingClientWrapperUnderTest.queryCustomObject(customObjectName, filterType, searchFields, requestFields);
 
@@ -212,7 +212,7 @@ describe('CachingClientWrapper', () => {
     const filterType = 'anyFilterType';
     const searchFields = [{ anySearchField: 'anySearchFieldValue' }];
     const requestFields = ['anyField'];
-    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap);
+    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap, null);
     cachingClientWrapperUnderTest.getAsync = sinon.stub();
     cachingClientWrapperUnderTest.getAsync.returns('"expectedCachedValue"');
     let actualCachedValue: string;
@@ -230,7 +230,7 @@ describe('CachingClientWrapper', () => {
   it('createOrUpdateCustomObject', (done) => {
     const customObjectName = 'any';
     const customObject = { anyField: 'anyValue' };
-    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap);
+    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap, null);
     cachingClientWrapperUnderTest.clearCache = sinon.spy();
     cachingClientWrapperUnderTest.createOrUpdateCustomObject(customObjectName, customObject);
 
@@ -244,7 +244,7 @@ describe('CachingClientWrapper', () => {
   it('deleteCustomObjectById', (done) => {
     const customObjectName = 'any';
     const customObjectGUID = 'anyGUID';
-    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap);
+    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap, null);
     cachingClientWrapperUnderTest.clearCache = sinon.spy();
     cachingClientWrapperUnderTest.deleteCustomObjectById(customObjectName, customObjectGUID);
 
@@ -256,7 +256,7 @@ describe('CachingClientWrapper', () => {
   });
 
   it('getCampaigns using original function', (done) => {
-    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap);
+    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap, null);
     cachingClientWrapperUnderTest.getAsync = sinon.stub().returns(false);
     cachingClientWrapperUnderTest.getCampaigns();
 
@@ -267,7 +267,7 @@ describe('CachingClientWrapper', () => {
   });
 
   it('getCampaigns using cache', (done) => {
-    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap);
+    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap, null);
     cachingClientWrapperUnderTest.getAsync = sinon.stub().returns('"expectedCachedValue"');
     let actualCachedValue: string;
     (async () => {
@@ -284,7 +284,7 @@ describe('CachingClientWrapper', () => {
   it('addLeadToSmartCampaign', (done) => {
     const campaignIdInput = 'someId';
     const leadInput = { name: 'someLead' };
-    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap);
+    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap, null);
     cachingClientWrapperUnderTest.clearCache = sinon.spy();
     cachingClientWrapperUnderTest.addLeadToSmartCampaign(campaignIdInput, leadInput);
 
@@ -296,7 +296,7 @@ describe('CachingClientWrapper', () => {
   });
 
   it('getActivityTypes using original function', (done) => {
-    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap);
+    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap, null);
     cachingClientWrapperUnderTest.getActivityTypes();
 
     expect(clientWrapperStub.getActivityTypes).to.have.been.called;
@@ -305,7 +305,7 @@ describe('CachingClientWrapper', () => {
 
   it('getActivityPagingToken using original function', (done) => {
     const sinceDate = 'anyDate';
-    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap);
+    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap, null);
     cachingClientWrapperUnderTest.getActivityPagingToken(sinceDate);
 
     expect(clientWrapperStub.getActivityPagingToken).to.have.been.calledWith(sinceDate);
@@ -316,7 +316,7 @@ describe('CachingClientWrapper', () => {
     const nextPageToken = 'anyToken';
     const leadId = 'anyId';
     const activityId = 'anyActivityId';
-    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap);
+    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap, null);
     cachingClientWrapperUnderTest.getActivitiesByLeadId(nextPageToken, leadId, activityId);
 
     expect(clientWrapperStub.getActivitiesByLeadId).to.have.been.calledWith(nextPageToken, leadId, activityId);
@@ -324,7 +324,7 @@ describe('CachingClientWrapper', () => {
   });
 
   it('getDailyApiUsage using original function', (done) => {
-    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap);
+    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap, null);
     cachingClientWrapperUnderTest.getDailyApiUsage();
 
     expect(clientWrapperStub.getDailyApiUsage).to.have.been.called;
@@ -332,7 +332,7 @@ describe('CachingClientWrapper', () => {
   });
 
   it('getWeeklyApiUsage using original function', (done) => {
-    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap);
+    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap, null);
     cachingClientWrapperUnderTest.getWeeklyApiUsage();
 
     expect(clientWrapperStub.getWeeklyApiUsage).to.have.been.called;
@@ -342,7 +342,7 @@ describe('CachingClientWrapper', () => {
   it('mergeLeadsById using original function', (done) => {
     const winningId = '1';
     const losingIds = ['2'];
-    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap);
+    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap, null);
     cachingClientWrapperUnderTest.clearCache = sinon.spy();
     cachingClientWrapperUnderTest.mergeLeadsById(winningId, losingIds);
 
@@ -355,7 +355,7 @@ describe('CachingClientWrapper', () => {
 
   it('getCache', (done) => {
     redisClientStub.get = sinon.stub().yields();
-    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap);
+    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap, null);
     cachingClientWrapperUnderTest.getCache('expectedKey');
 
     setTimeout(() => {
@@ -366,7 +366,7 @@ describe('CachingClientWrapper', () => {
 
   it('setCache', (done) => {
     redisClientStub.setex = sinon.stub().yields(); 
-    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap);
+    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap, null);
     cachingClientWrapperUnderTest.getCache = sinon.stub().returns(null);
     cachingClientWrapperUnderTest.cachePrefix = 'testPrefix';
     cachingClientWrapperUnderTest.setCache('expectedKey', 'expectedValue');
@@ -380,7 +380,7 @@ describe('CachingClientWrapper', () => {
 
   it('clearCache', (done) => {
     redisClientStub.del = sinon.stub().yields();
-    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap);
+    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap, null);
     cachingClientWrapperUnderTest.cachePrefix = 'testPrefix';
     cachingClientWrapperUnderTest.getCache = sinon.stub().returns(['testKey1', 'testKey2'])
     cachingClientWrapperUnderTest.clearCache();

--- a/test/steps/program-members/program-member-add-or-remove.ts
+++ b/test/steps/program-members/program-member-add-or-remove.ts
@@ -1,0 +1,401 @@
+import { Struct } from 'google-protobuf/google/protobuf/struct_pb';
+import * as chai from 'chai';
+import { default as sinon } from 'ts-sinon';
+import * as sinonChai from 'sinon-chai';
+import 'mocha';
+
+import { Step as ProtoStep, StepDefinition, FieldDefinition, RunStepResponse } from '../../../src/proto/cog_pb';
+import { Step } from '../../../src/steps/program-members/program-member-add-or-remove';
+
+chai.use(sinonChai);
+
+describe('AddOrRemoveProgramMemberStep', () => {
+  const expect = chai.expect;
+  let protoStep: ProtoStep;
+  let stepUnderTest: Step;
+  let clientWrapperStub: any;
+
+  beforeEach(() => {
+    protoStep = new ProtoStep();
+    clientWrapperStub = sinon.stub();
+    clientWrapperStub.bulkSetStatusToLeadsFromProgram = sinon.stub();
+    clientWrapperStub.bulkRemoveLeadsFromProgram = sinon.stub();
+    clientWrapperStub.bulkFindLeadsByEmail = sinon.stub();
+    clientWrapperStub.bulkFindLeadsById = sinon.stub();
+    stepUnderTest = new Step(clientWrapperStub);
+  });
+
+  it('should return expected step metadata', () => {
+    const stepDef: StepDefinition = stepUnderTest.getDefinition();
+    expect(stepDef.getStepId()).to.equal('AddOrRemoveProgramMemberStep');
+    expect(stepDef.getName()).to.equal('Add or Remove Marketo Program Members');
+    expect(stepDef.getExpression()).to.equal('add or remove marketo program members');
+    expect(stepDef.getType()).to.equal(StepDefinition.Type.ACTION);
+  });
+
+  it('should return expected step fields', () => {
+    const stepDef: StepDefinition = stepUnderTest.getDefinition();
+    const fields: any[] = stepDef.getExpectedFieldsList().map((field: FieldDefinition) => {
+      return field.toObject();
+    });
+    expect(fields[0].key).to.equal('partitionId');
+    expect(fields[0].type).to.equal(FieldDefinition.Type.NUMERIC);
+    expect(fields[0].optionality).to.equal(FieldDefinition.Optionality.OPTIONAL);
+    expect(fields[1].key).to.equal('programId');
+    expect(fields[1].type).to.equal(FieldDefinition.Type.STRING);
+    expect(fields[1].optionality).to.equal(FieldDefinition.Optionality.REQUIRED);
+    expect(fields[2].key).to.equal('memberStatus');
+    expect(fields[2].type).to.equal(FieldDefinition.Type.STRING);
+    expect(fields[2].optionality).to.equal(FieldDefinition.Optionality.REQUIRED);
+    expect(fields[3].key).to.equal('email');
+    expect(fields[3].type).to.equal(FieldDefinition.Type.STRING);
+    expect(fields[3].optionality).to.equal(FieldDefinition.Optionality.REQUIRED);
+  });
+
+  it('should call the client wrapper with the expected args', async () => {
+    const expectedEmails: string[] = [
+      'sampleEmail1@example.com',
+      'sampleEmail2@example.com',
+      'sampleEmail3@example.com',
+    ];
+    
+    clientWrapperStub.bulkFindLeadsByEmail.returns(Promise.resolve([
+      {
+        success: true,
+        result: [
+          {
+            email: 'sampleEmail1@example.com',
+            leadId: 123321,
+          },
+          {
+            email: 'sampleEmail2@example.com',
+            leadId: 123322,
+          },
+          {
+            email: 'sampleEmail3@example.com',
+            leadId: 123323,
+          },
+        ],
+      },
+    ]));
+    
+    protoStep.setData(Struct.fromJavaScript({
+      multiple_email: expectedEmails
+    }));
+
+    await stepUnderTest.executeStep(protoStep);
+    expect(clientWrapperStub.bulkSetStatusToLeadsFromProgram).to.have.been.calledWith(expectedEmails);
+  });
+
+  it('should respond with success if the marketo executes succesfully with multiple emails', async () => {
+    clientWrapperStub.bulkFindLeadsByEmail.returns(Promise.resolve([
+      {
+        success: true,
+        result: [
+          {
+            email: 'sampleEmail1@example.com',
+            leadId: 123321,
+          },
+          {
+            email: 'sampleEmail2@example.com',
+            leadId: 123322,
+          },
+          {
+            email: 'sampleEmail3@example.com',
+            leadId: 123323,
+          },
+        ],
+      },
+    ]));
+    
+    clientWrapperStub.bulkSetStatusToLeadsFromProgram.returns(Promise.resolve([
+      {
+        success: true,
+        result: [
+          {
+            status: 'created',
+            leadId: 123321,
+          },
+          {
+            status: 'updated',
+            leadId: 123322,
+          },
+          {
+            status: 'updated',
+            leadId: 123323,
+          },
+        ],
+      },
+    ]));
+    protoStep.setData(Struct.fromJavaScript({
+      programId: 'anyId',
+      multiple_email: [
+        'sampleEmail1@example.com',
+        'sampleEmail2@example.com',
+        'sampleEmail3@example.com',
+      ],
+    }));
+    const response: RunStepResponse = (await stepUnderTest.executeStep(protoStep)) as RunStepResponse;
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+  });
+  
+  it('should respond with success if the marketo executes succesfully with multiple ids', async () => {
+    clientWrapperStub.bulkFindLeadsById.returns(Promise.resolve([
+      {
+        success: true,
+        result: [
+          {
+            email: 'sampleEmail1@example.com',
+            leadId: 123321,
+          },
+          {
+            email: 'sampleEmail2@example.com',
+            leadId: 123322,
+          },
+          {
+            email: 'sampleEmail3@example.com',
+            leadId: 123323,
+          },
+        ],
+      },
+    ]));
+    
+    clientWrapperStub.bulkSetStatusToLeadsFromProgram.returns(Promise.resolve([
+      {
+        success: true,
+        result: [
+          {
+            status: 'created',
+            leadId: 123321,
+          },
+          {
+            status: 'updated',
+            leadId: 123322,
+          },
+          {
+            status: 'updated',
+            leadId: 123323,
+          },
+        ],
+      },
+    ]));
+    protoStep.setData(Struct.fromJavaScript({
+      programId: 'anyId',
+      multiple_email: [
+        123321,
+        123322,
+        123323,
+      ],
+    }));
+    const response: RunStepResponse = (await stepUnderTest.executeStep(protoStep)) as RunStepResponse;
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+  });
+  
+  it('should respond with success if the marketo executes succesfully with single email', async () => {
+    clientWrapperStub.findLeadByEmail = sinon.stub();
+    clientWrapperStub.findLeadByEmail.returns(Promise.resolve({
+        success: true,
+        result: [
+          {
+            email: 'sampleEmail1@example.com',
+            leadId: 123321,
+          },
+        ],
+      }));
+    
+    clientWrapperStub.bulkSetStatusToLeadsFromProgram.returns(Promise.resolve([
+      {
+        success: true,
+        result: [
+          {
+            status: 'created',
+            leadId: 123321,
+          },
+        ],
+      },
+    ]));
+    protoStep.setData(Struct.fromJavaScript({
+      programId: 'anyId',
+      email: 'sampleEmail1@example.com',
+    }));
+    const response: RunStepResponse = (await stepUnderTest.executeStep(protoStep)) as RunStepResponse;
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+  });
+  
+  it('should respond with success if the marketo executes succesfully with a single id', async () => {
+    clientWrapperStub.findLeadByField = sinon.stub();
+    clientWrapperStub.findLeadByField.returns(Promise.resolve({
+        success: true,
+        result: [
+          {
+            email: 'sampleEmail1@example.com',
+            leadId: 123321,
+          },
+        ],
+      }));
+    
+    clientWrapperStub.bulkSetStatusToLeadsFromProgram.returns(Promise.resolve([
+      {
+        success: true,
+        result: [
+          {
+            status: 'created',
+            leadId: 123321,
+          },
+        ],
+      },
+    ]));
+    protoStep.setData(Struct.fromJavaScript({
+      programId: 'anyId',
+      email: '123321',
+    }));
+    const response: RunStepResponse = (await stepUnderTest.executeStep(protoStep)) as RunStepResponse;
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+  });
+
+  it('should respond with fail if the partition does not exist', async () => {
+    clientWrapperStub.bulkFindLeadsByEmail.returns(Promise.resolve([
+      {
+        success: true,
+        result: [
+          {
+            email: 'sampleEmail1@example.com',
+            leadId: 123321,
+          },
+          {
+            email: 'sampleEmail2@example.com',
+            leadId: 123322,
+          },
+          {
+            email: 'sampleEmail3@example.com',
+            leadId: 123323,
+          },
+        ],
+      },
+    ]));
+    clientWrapperStub.bulkSetStatusToLeadsFromProgram.returns(Promise.resolve([{ error: { partition: false } }]));
+    protoStep.setData(Struct.fromJavaScript({
+      partitionId: 23,
+      programId: 'anyId',
+      multiple_email: [
+        'sampleEmail1@example.com',
+        'sampleEmail2@example.com',
+        'sampleEmail3@example.com',
+      ],
+    }));
+    const response: RunStepResponse = (await stepUnderTest.executeStep(protoStep)) as RunStepResponse;
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.FAILED);
+  });
+  
+  it('should respond with error if not all leads are found', async () => {
+    clientWrapperStub.bulkFindLeadsByEmail.returns(Promise.resolve([
+      {
+        success: true,
+        result: [
+          {
+            email: 'sampleEmail1@example.com',
+            leadId: 123321,
+          },
+          {
+            email: 'sampleEmail2@example.com',
+            leadId: 123322,
+          },
+        ],
+      },
+    ]));
+    protoStep.setData(Struct.fromJavaScript({
+      programId: 'anyId',
+      multiple_email: [
+        'sampleEmail1@example.com',
+        'sampleEmail2@example.com',
+        'sampleEmail3@example.com',
+      ],
+    }));
+    const response: RunStepResponse = (await stepUnderTest.executeStep(protoStep)) as RunStepResponse;
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
+  });
+
+  it('should respond with fail if marketo skips adding or removing of member', async () => {
+    clientWrapperStub.bulkFindLeadsByEmail.returns(Promise.resolve([
+      {
+        success: true,
+        result: [
+          {
+            email: 'sampleEmail1@example.com',
+            leadId: 123321,
+          },
+          {
+            email: 'sampleEmail2@example.com',
+            leadId: 123322,
+          },
+          {
+            email: 'sampleEmail3@example.com',
+            leadId: 123323,
+          },
+        ],
+      },
+    ]));
+    
+    clientWrapperStub.bulkSetStatusToLeadsFromProgram.returns(Promise.resolve([{
+      success: true,
+      result: [
+        {
+          status: 'created',
+          leadId: 123321,
+        },
+        {
+          status: 'skipped',
+        },
+        {
+          status: 'updated',
+          leadId: 123323,
+        },
+      ],
+    }]));
+    protoStep.setData(Struct.fromJavaScript({
+      programId: 'anyId',
+      multiple_email: [
+        'sampleEmail1@example.com',
+        'sampleEmail2@example.com',
+        'sampleEmail3@example.com',
+      ],
+    }));
+    const response: RunStepResponse = (await stepUnderTest.executeStep(protoStep)) as RunStepResponse;
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.FAILED);
+  });
+
+  it('should respond with an error if the marketo throws an error', async () => {
+    clientWrapperStub.bulkFindLeadsByEmail.returns(Promise.resolve([
+      {
+        success: true,
+        result: [
+          {
+            email: 'sampleEmail1@example.com',
+            leadId: 123321,
+          },
+          {
+            email: 'sampleEmail2@example.com',
+            leadId: 123322,
+          },
+          {
+            email: 'sampleEmail3@example.com',
+            leadId: 123323,
+          },
+        ],
+      },
+    ]));
+    
+    clientWrapperStub.bulkSetStatusToLeadsFromProgram.throws('any error');
+    protoStep.setData(Struct.fromJavaScript({
+      programId: 'anyId',
+      multiple_email: [
+        'sampleEmail1@example.com',
+        'sampleEmail2@example.com',
+        'sampleEmail3@example.com',
+      ],
+    }));
+    const response: RunStepResponse = (await stepUnderTest.executeStep(protoStep)) as RunStepResponse;
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
+  });
+
+});

--- a/test/steps/smart-campaign-add-lead.ts
+++ b/test/steps/smart-campaign-add-lead.ts
@@ -15,197 +15,373 @@ describe('AddLeadToSmartCampaignStep', () => {
   let stepUnderTest: Step;
   let clientWrapperStub: any;
 
-  beforeEach(() => {
-    protoStep = new ProtoStep();
-    clientWrapperStub = sinon.stub();
-    clientWrapperStub.getCampaigns = sinon.stub();
-    clientWrapperStub.findLeadByField = sinon.stub();
-    clientWrapperStub.addLeadToSmartCampaign = sinon.stub();
-    stepUnderTest = new Step(clientWrapperStub);
-  });
+  describe('Single Lead', () => {
 
-  it('should return expected step metadata', () => {
-    const stepDef: StepDefinition = stepUnderTest.getDefinition();
-    expect(stepDef.getStepId()).to.equal('AddLeadToSmartCampaignStep');
-    expect(stepDef.getName()).to.equal('Add Marketo Lead to Smart Campaign');
-    expect(stepDef.getExpression()).to.equal('add the (?<email>.+) marketo lead to smart campaign (?<campaign>.+)');
-    expect(stepDef.getType()).to.equal(StepDefinition.Type.ACTION);
-  });
-
-  it('should return expected step fields', () => {
-    const stepDef: StepDefinition = stepUnderTest.getDefinition();
-    const fields: any[] = stepDef.getExpectedFieldsList().map((field: FieldDefinition) => {
-      return field.toObject();
+    beforeEach(() => {
+      protoStep = new ProtoStep();
+      clientWrapperStub = sinon.stub();
+      clientWrapperStub.getCampaigns = sinon.stub();
+      clientWrapperStub.findLeadByField = sinon.stub();
+      clientWrapperStub.addLeadToSmartCampaign = sinon.stub();
+      stepUnderTest = new Step(clientWrapperStub);
     });
 
-    // Email field
-    expect(fields[0].key).to.equal('email');
-    expect(fields[0].optionality).to.equal(FieldDefinition.Optionality.REQUIRED);
-    expect(fields[0].type).to.equal(FieldDefinition.Type.STRING);
+    it('should return expected step metadata', () => {
+      const stepDef: StepDefinition = stepUnderTest.getDefinition();
+      expect(stepDef.getStepId()).to.equal('AddLeadToSmartCampaignStep');
+      expect(stepDef.getName()).to.equal('Add Marketo Lead to Smart Campaign');
+      expect(stepDef.getExpression()).to.equal('add the (?<email>.+) marketo lead to smart campaign (?<campaign>.+)');
+      expect(stepDef.getType()).to.equal(StepDefinition.Type.ACTION);
+    });
 
-    // Campaign field
-    expect(fields[1].key).to.equal('campaign');
-    expect(fields[1].optionality).to.equal(FieldDefinition.Optionality.REQUIRED);
-    expect(fields[1].type).to.equal(FieldDefinition.Type.ANYSCALAR);
+    it('should return expected step fields', () => {
+      const stepDef: StepDefinition = stepUnderTest.getDefinition();
+      const fields: any[] = stepDef.getExpectedFieldsList().map((field: FieldDefinition) => {
+        return field.toObject();
+      });
 
-    // Partition ID field
-    expect(fields[2].key).to.equal('partitionId');
-    expect(fields[2].optionality).to.equal(FieldDefinition.Optionality.OPTIONAL);
-    expect(fields[2].type).to.equal(FieldDefinition.Type.NUMERIC);
-  });
+      // Email field
+      expect(fields[0].key).to.equal('email');
+      expect(fields[0].optionality).to.equal(FieldDefinition.Optionality.REQUIRED);
+      expect(fields[0].type).to.equal(FieldDefinition.Type.STRING);
 
-  it('should respond with success if the marketo executes succesfully with non numeric campaign', async () => {
-    const expectedResponseMessage: string = 'Successfully added lead %s to smart campaign %s';
-    clientWrapperStub.getCampaigns.returns(Promise.resolve([
-      {
-        name: 'someCampaign',
-        id: '11111',
-        isRequestable: true,
-      },
-    ]));
-    clientWrapperStub.findLeadByField.returns(Promise.resolve({
-      success: true,
-      result: [
+      // Campaign field
+      expect(fields[1].key).to.equal('campaign');
+      expect(fields[1].optionality).to.equal(FieldDefinition.Optionality.REQUIRED);
+      expect(fields[1].type).to.equal(FieldDefinition.Type.ANYSCALAR);
+
+      // Partition ID field
+      expect(fields[2].key).to.equal('partitionId');
+      expect(fields[2].optionality).to.equal(FieldDefinition.Optionality.OPTIONAL);
+      expect(fields[2].type).to.equal(FieldDefinition.Type.NUMERIC);
+    });
+
+    it('should respond with success if the marketo executes succesfully with non numeric campaign', async () => {
+      const expectedResponseMessage: string = 'Successfully added lead %s to smart campaign %s';
+      clientWrapperStub.getCampaigns.returns(Promise.resolve([
         {
-          name: 'someLead',
-          email: 'someEmail',
+          name: 'someCampaign',
+          id: '11111',
+          isRequestable: true,
         },
-      ],
-    }));
-    clientWrapperStub.addLeadToSmartCampaign.returns(Promise.resolve({
-      success: true,
-      result: [{}],
-    }));
-    protoStep.setData(Struct.fromJavaScript({
-      email: 'someEmail',
-      campaign: 'someCampaign',
-    }));
-    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
-    expect(response.getMessageFormat()).to.equal(expectedResponseMessage);
-    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
-  });
+      ]));
+      clientWrapperStub.findLeadByField.returns(Promise.resolve({
+        success: true,
+        result: [
+          {
+            name: 'someLead',
+            email: 'someEmail',
+          },
+        ],
+      }));
+      clientWrapperStub.addLeadToSmartCampaign.returns(Promise.resolve({
+        success: true,
+        result: [{}],
+      }));
+      protoStep.setData(Struct.fromJavaScript({
+        email: 'someEmail',
+        campaign: 'someCampaign',
+      }));
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getMessageFormat()).to.equal(expectedResponseMessage);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+    });
 
-  it('should respond with success if the marketo executes succesfully with numeric campaign', async () => {
-    const expectedResponseMessage: string = 'Successfully added lead %s to smart campaign %s';
-    clientWrapperStub.getCampaigns.returns(Promise.resolve([
-      {
-        name: 'someCampaign',
-        id: '11111',
-        isRequestable: true,
-      },
-    ]));
-    clientWrapperStub.findLeadByField.returns(Promise.resolve({
-      success: true,
-      result: [
+    it('should respond with success if the marketo executes succesfully with numeric campaign', async () => {
+      const expectedResponseMessage: string = 'Successfully added lead %s to smart campaign %s';
+      clientWrapperStub.getCampaigns.returns(Promise.resolve([
         {
-          name: 'someLead',
-          email: 'someEmail',
+          name: 'someCampaign',
+          id: '11111',
+          isRequestable: true,
         },
-      ],
-    }));
-    clientWrapperStub.addLeadToSmartCampaign.returns(Promise.resolve({
-      success: true,
-      result: [{}],
-    }));
-    protoStep.setData(Struct.fromJavaScript({
-      email: 'someEmail',
-      campaign: '11111',
-    }));
-    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
-    expect(response.getMessageFormat()).to.equal(expectedResponseMessage);
-    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
-  });
+      ]));
+      clientWrapperStub.findLeadByField.returns(Promise.resolve({
+        success: true,
+        result: [
+          {
+            name: 'someLead',
+            email: 'someEmail',
+          },
+        ],
+      }));
+      clientWrapperStub.addLeadToSmartCampaign.returns(Promise.resolve({
+        success: true,
+        result: [{}],
+      }));
+      protoStep.setData(Struct.fromJavaScript({
+        email: 'someEmail',
+        campaign: '11111',
+      }));
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getMessageFormat()).to.equal(expectedResponseMessage);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+    });
 
-  it('should respond with error if the marketo returns more than 1 campaign', async () => {
-    const expectedResponseMessage: string = "Can't add %s to %s: found %d matching campaigns";
-    clientWrapperStub.getCampaigns.returns(Promise.resolve([
-      {
-        name: 'someCampaign',
-        id: '11111',
-        isRequestable: true,
-      },
-      {
-        name: 'someCampaign',
-        id: '22222',
-        isRequestable: true,
-      },
-    ]));
-    protoStep.setData(Struct.fromJavaScript({
-      email: 'someEmail',
-      campaign: 'someCampaign',
-    }));
-    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
-    expect(response.getMessageFormat()).to.equal(expectedResponseMessage);
-    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
-  });
-
-  it('should respond with an error if the marketo throws an error related to trigger campaign', async () => {
-    const expectedResponseMessage: string = "Cannot add lead to smart campaign %s. In order to test this campaign, you must add a 'Campaign is Requested' trigger with 'Source' set to 'Web Service API'";
-    clientWrapperStub.getCampaigns.returns(Promise.resolve([
-      {
-        name: 'someCampaign',
-        id: '11111',
-      },
-    ]));
-    clientWrapperStub.findLeadByField.returns(Promise.resolve({
-      success: true,
-      result: [
+    it('should respond with error if the marketo returns more than 1 campaign', async () => {
+      const expectedResponseMessage: string = "Can't add lead(s) to %s: found %d matching campaigns";
+      clientWrapperStub.getCampaigns.returns(Promise.resolve([
         {
-          name: 'someLead',
-          email: 'someEmail',
+          name: 'someCampaign',
+          id: '11111',
+          isRequestable: true,
         },
-      ],
-    }));
-    clientWrapperStub.addLeadToSmartCampaign.throws({ message: "Trigger campaign needs to have a 'Campaign Requested' trigger" });
-    protoStep.setData(Struct.fromJavaScript({
-      email: 'someEmail',
-      campaign: 'someCampaign',
-    }));
-    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
-    expect(response.getMessageFormat()).to.equal(expectedResponseMessage);
-    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
-  });
-
-  it('should respond with fail if the marketo fails to add lead to smart campaign', async () => {
-    const expectedResponseMessage: string = 'Unable to add lead %s to smart campaign %s: %s';
-    clientWrapperStub.getCampaigns.returns(Promise.resolve([
-      {
-        name: 'someCampaign',
-        id: '11111',
-        isRequestable: true,
-      },
-    ]));
-    clientWrapperStub.findLeadByField.returns(Promise.resolve({
-      success: true,
-      result: [
         {
-          name: 'someLead',
-          email: 'someEmail',
+          name: 'someCampaign',
+          id: '22222',
+          isRequestable: true,
         },
-      ],
-    }));
-    clientWrapperStub.addLeadToSmartCampaign.returns(Promise.resolve({
-      success: false,
-      result: [{}],
-      message: 'someError',
-    }));
-    protoStep.setData(Struct.fromJavaScript({
-      email: 'someEmail',
-      campaign: 'someCampaign',
-    }));
-    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
-    expect(response.getMessageFormat()).to.equal(expectedResponseMessage);
-    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.FAILED);
-  });
+      ]));
+      protoStep.setData(Struct.fromJavaScript({
+        email: 'someEmail',
+        campaign: 'someCampaign',
+      }));
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getMessageFormat()).to.equal(expectedResponseMessage);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
+    });
 
-  it('should respond with an error if the marketo throws an error', async () => {
-    clientWrapperStub.getCampaigns.throws('any error');
-    protoStep.setData(Struct.fromJavaScript({
-      email: 'someEmail',
-      campaign: 'someCampaign',
-    }));
-    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
-    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
-  });
+    it('should respond with an error if the marketo throws an error related to trigger campaign', async () => {
+      const expectedResponseMessage: string = "Cannot add lead to smart campaign %s. In order to test this campaign, you must add a 'Campaign is Requested' trigger with 'Source' set to 'Web Service API'";
+      clientWrapperStub.getCampaigns.returns(Promise.resolve([
+        {
+          name: 'someCampaign',
+          id: '11111',
+        },
+      ]));
+      clientWrapperStub.findLeadByField.returns(Promise.resolve({
+        success: true,
+        result: [
+          {
+            name: 'someLead',
+            email: 'someEmail',
+          },
+        ],
+      }));
+      clientWrapperStub.addLeadToSmartCampaign.throws({ message: "Trigger campaign needs to have a 'Campaign Requested' trigger" });
+      protoStep.setData(Struct.fromJavaScript({
+        email: 'someEmail',
+        campaign: 'someCampaign',
+      }));
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getMessageFormat()).to.equal(expectedResponseMessage);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
+    });
 
-});
+    it('should respond with fail if the marketo fails to add lead to smart campaign', async () => {
+      const expectedResponseMessage: string = 'Unable to add lead %s to smart campaign %s: %s';
+      clientWrapperStub.getCampaigns.returns(Promise.resolve([
+        {
+          name: 'someCampaign',
+          id: '11111',
+          isRequestable: true,
+        },
+      ]));
+      clientWrapperStub.findLeadByField.returns(Promise.resolve({
+        success: true,
+        result: [
+          {
+            name: 'someLead',
+            email: 'someEmail',
+          },
+        ],
+      }));
+      clientWrapperStub.addLeadToSmartCampaign.returns(Promise.resolve({
+        success: false,
+        result: [{}],
+        message: 'someError',
+      }));
+      protoStep.setData(Struct.fromJavaScript({
+        email: 'someEmail',
+        campaign: 'someCampaign',
+      }));
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getMessageFormat()).to.equal(expectedResponseMessage);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.FAILED);
+    });
+
+    it('should respond with an error if the marketo throws an error', async () => {
+      clientWrapperStub.getCampaigns.returns([]);
+      protoStep.setData(Struct.fromJavaScript({
+        email: 'someEmail',
+        campaign: 'someCampaign',
+      }));
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
+    });
+
+  });
+  
+  describe('Bulk Leads', () => {
+
+    beforeEach(() => {
+      protoStep = new ProtoStep();
+      clientWrapperStub = sinon.stub();
+      clientWrapperStub.getCampaigns = sinon.stub();
+      clientWrapperStub.bulkFindLeadsByEmail = sinon.stub();
+      clientWrapperStub.bulkAddLeadToSmartCampaign = sinon.stub();
+      stepUnderTest = new Step(clientWrapperStub);
+    });
+
+    it('should respond with passed if multiple leads are succesfully added', async () => {
+      const expectedResponseMessage: string = 'Successfully added %d leads to smart campaign %s';
+      clientWrapperStub.getCampaigns.returns(Promise.resolve([
+        {
+          name: 'someCampaign',
+          id: '11111',
+          isRequestable: true,
+        },
+      ]));
+      clientWrapperStub.bulkFindLeadsByEmail.returns(Promise.resolve({
+        success: true,
+        result: [
+          {
+            name: 'firstLead',
+            email: 'firstEmail',
+            id: '1'
+          },
+          {
+            name: 'secondLead',
+            email: 'secondEmail',
+            id: '2'
+          },
+        ],
+      }));
+      clientWrapperStub.bulkAddLeadToSmartCampaign.returns(Promise.resolve({
+        passedLeads: ['1', '2'],
+        failedLeads: {}
+      }));
+      protoStep.setData(Struct.fromJavaScript({
+        campaign: 'someCampaign',
+        multiple_email: ['firstEmail', 'secondEmail']
+      }));
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getMessageFormat()).to.equal(expectedResponseMessage);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+    });
+    
+    it('should respond with passed if multiple leads are succesfully added using ID', async () => {
+      const expectedResponseMessage: string = 'Successfully added %d leads to smart campaign %s';
+      clientWrapperStub.getCampaigns.returns(Promise.resolve([
+        {
+          name: 'someCampaign',
+          id: '11111',
+          isRequestable: true,
+        },
+      ]));
+      clientWrapperStub.bulkAddLeadToSmartCampaign.returns(Promise.resolve({
+        passedLeads: ['1', '2'],
+        failedLeads: {}
+      }));
+      protoStep.setData(Struct.fromJavaScript({
+        campaign: 'someCampaign',
+        multiple_email: [1,2]
+      }));
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getMessageFormat()).to.equal(expectedResponseMessage);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+    });
+
+    it('should respond with fail if only some leads are succesfully added', async () => {
+      const expectedResponseMessage: string = 'Successfully added %d out of %d leads to smart campaign %s';
+      clientWrapperStub.getCampaigns.returns(Promise.resolve([
+        {
+          name: 'someCampaign',
+          id: '11111',
+          isRequestable: true,
+        },
+      ]));
+      clientWrapperStub.bulkFindLeadsByEmail.returns(Promise.resolve({
+        success: true,
+        result: [
+          {
+            name: 'firstLead',
+            email: 'firstEmail',
+            id: '1'
+          },
+          {
+            name: 'secondLead',
+            email: 'secondEmail',
+            id: '2'
+          },
+        ],
+      }));
+      clientWrapperStub.bulkAddLeadToSmartCampaign.returns(Promise.resolve({
+        passedLeads: ['1'],
+        failedLeads: {'2': 'lead 2 not found'}
+      }));
+      protoStep.setData(Struct.fromJavaScript({
+        campaign: 'someCampaign',
+        multiple_email: ['firstEmail', 'secondEmail']
+      }));
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getMessageFormat()).to.equal(expectedResponseMessage);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.FAILED);
+    });
+
+    it('should respond with failed if no leads are successfully added', async () => {
+      const expectedResponseMessage: string = 'Failed to add %d leads to smart campaign %s';
+      clientWrapperStub.getCampaigns.returns(Promise.resolve([
+        {
+          name: 'someCampaign',
+          id: '11111',
+          isRequestable: true,
+        },
+      ]));
+      clientWrapperStub.bulkFindLeadsByEmail.returns(Promise.resolve({
+        success: true,
+        result: [
+          {
+            name: 'firstLead',
+            email: 'firstEmail',
+            id: '1'
+          },
+          {
+            name: 'secondLead',
+            email: 'secondEmail',
+            id: '2'
+          },
+        ],
+      }));
+      clientWrapperStub.bulkAddLeadToSmartCampaign.returns(Promise.resolve({
+        passedLeads: [],
+        failedLeads: {'1': 'lead 1 not found', '2': 'lead 2 not found'}
+      }));
+      protoStep.setData(Struct.fromJavaScript({
+        campaign: 'someCampaign',
+        multiple_email: ['firstEmail', 'secondEmail']
+      }));
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getMessageFormat()).to.equal(expectedResponseMessage);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.FAILED);
+    });
+
+    it('should respond with error if not all leads are found', async () => {
+      const expectedResponseMessage: string = 'Could not find all leads provided in partition %d';
+      clientWrapperStub.getCampaigns.returns(Promise.resolve([
+        {
+          name: 'someCampaign',
+          id: '11111',
+          isRequestable: true,
+        },
+      ]));
+      clientWrapperStub.bulkFindLeadsByEmail.returns(Promise.resolve([{
+        success: true,
+        result: [
+          {
+            name: 'secondLead',
+            email: 'secondEmail',
+            id: '2'
+          },
+        ],
+      }]));
+      protoStep.setData(Struct.fromJavaScript({
+        campaign: 'someCampaign',
+        multiple_email: ['firstEmail@example.com', 'secondEmail@example.com']
+      }));
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getMessageFormat()).to.equal(expectedResponseMessage);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
+    });
+  });
+})

--- a/test/steps/static-lists/static-list-add-lead.ts
+++ b/test/steps/static-lists/static-list-add-lead.ts
@@ -59,13 +59,19 @@ describe('AddLeadToStaticListStep', () => {
     clientWrapperStub.addLeadToStaticList.returns(Promise.resolve({
       success: true,
       result: [{
-          id: 'anyId',
-          status: 'added',
+        id: 1,
+        status: 'added',
+      },{
+        id: 2,
+        status: 'added',
+      },{
+        id: 3,
+        status: 'added',
       }],
     }));
     protoStep.setData(Struct.fromJavaScript({
       staticListName: 'someEmail',
-      leadIds: 'anyId, anyId, anyId',
+      leadIds: '1, 2, 3',
     }));
     const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
     expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
@@ -115,7 +121,7 @@ describe('AddLeadToStaticListStep', () => {
     expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
   });
 
-  it('should respond with error if the marketo call was not successful', async () => {
+  it('should respond with fail if the marketo call was not successful', async () => {
     clientWrapperStub.findStaticListsByName.returns(Promise.resolve({
       success: true,
       result: [{
@@ -125,6 +131,7 @@ describe('AddLeadToStaticListStep', () => {
     }));
     clientWrapperStub.addLeadToStaticList.returns(Promise.resolve({
       success: false,
+      errors: [{ code: '1004', message: 'test error' }]
     }));
     protoStep.setData(Struct.fromJavaScript({
       staticListName: 'someEmail',
@@ -132,7 +139,7 @@ describe('AddLeadToStaticListStep', () => {
     }));
     
     const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
-    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.FAILED);
   });
 
   it('should respond with an error if the marketo throws an error', async () => {
@@ -143,6 +150,36 @@ describe('AddLeadToStaticListStep', () => {
     }));
     const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
     expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
+  });
+  
+  it('should respond with success step executes successfully with multiple_leadId input', async () => {
+    clientWrapperStub.findStaticListsByName.returns(Promise.resolve({
+      success: true,
+      result: [{
+        id: 'anyId',
+        name: 'anyName',
+      }],
+    }));
+    clientWrapperStub.addLeadToStaticList.returns(Promise.resolve({
+      success: true,
+      result: [{
+        id: 1,
+        status: 'added',
+      }, {
+        id: 2,
+        status: 'added',
+      }, {
+        id: 3,
+        status: 'added',
+    }],
+    }));
+    protoStep.setData(Struct.fromJavaScript({
+      staticListName: 'someEmail',
+      leadIds: '',
+      multiple_leadIds: [1,2,3]
+    }));
+    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
   });
 
 });


### PR DESCRIPTION
Includes bulk functionality for these steps:
- add or remove marketo program member (new step that accepts an email or id, or bulk tokens of either)
- add leads to static list (accepts existing comma separated list of ids, or bulk token with ids)
- add lead to smart campaign (accepts email or id, or bulk tokens of either)

Also includes tests for new functionality, as well as a new bulkSupport property on the Field interface, to keep track of which fields can accept a bulk token.