### PR TITLE
Sorting steps by action and targetObject

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -187,9 +187,9 @@
       }
     },
     "@run-crank/utilities": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@run-crank/utilities/-/utilities-0.5.1.tgz",
-      "integrity": "sha512-U9YS6zsu7/PCtJl6/PZRcnS8Dh3r4CWLyAg01MhUp7e5rkW2OXZUdosO0RcRYfQHWjs6flz8R2ATTo7TD/jsrQ==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@run-crank/utilities/-/utilities-0.5.2.tgz",
+      "integrity": "sha512-SaDLcj1a4cED3+8vCodc5Zuxmh0BBBgemVQtXiVbLACat/Qtqaj47gKM+CdzCYTrSYnv5c5ZxXjHGQ47LcP9jQ==",
       "requires": {
         "csv-string": "^4.0.1",
         "moment": "^2.24.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "build-docker": "docker build -t automatoninc/marketo:$npm_package_version -t automatoninc/marketo:latest .",
-    "build-proto": "scripts/build-proto.sh",
+    "build-proto": "bash scripts/build-proto.sh",
     "build-ts": "tsc",
     "lint": "tslint -c tslint.json -p tsconfig.json",
     "start": "check-engine package.json && node -r ts-node/register src/core/grpc-server.ts",
@@ -55,7 +55,7 @@
     "typescript": "^3.5.1"
   },
   "dependencies": {
-    "@run-crank/utilities": "^0.5.1",
+    "@run-crank/utilities": "^0.5.2",
     "google-protobuf": "^3.8.0",
     "grpc": "^1.24.3",
     "mailgun-js": "^0.22.0",

--- a/proto/cog.proto
+++ b/proto/cog.proto
@@ -247,7 +247,7 @@ message StepDefinition {
 
   /**
    * An optional-but-encouraged string describing the target object.
-   * This is mostly used for sorting the steps into different "Actions" on a front end web app.
+   * This is mostly used for sorting the steps into different "Target Objects" on a front end web app.
    * <br><br>
    * **An example**: For a "Create or Update Marketo Lead" step, the targetObject would be equal to 'lead'.
    */

--- a/proto/cog.proto
+++ b/proto/cog.proto
@@ -237,6 +237,22 @@ message StepDefinition {
    */
   repeated RecordDefinition expected_records = 7;
 
+  /**
+   * An optional-but-encouraged array of strings that contains any actions that the step performs.
+   * This is mostly used for sorting the steps into different "Actions" on a front end web app.
+   * <br><br>
+   * **An example**: For a "Create or Update Marketo Lead" step, the actions would be equal to ['create', 'update'].
+   */
+  repeated string action = 8;
+
+  /**
+   * An optional-but-encouraged string describing the target object.
+   * This is mostly used for sorting the steps into different "Actions" on a front end web app.
+   * <br><br>
+   * **An example**: For a "Create or Update Marketo Lead" step, the targetObject would be equal to 'lead'.
+   */
+  string target_object = 9;
+
 }
 
 /**

--- a/src/core/base-step.ts
+++ b/src/core/base-step.ts
@@ -35,6 +35,8 @@ export abstract class BaseStep {
   protected expectedFields: Field[];
   protected expectedRecords?: ExpectedRecord[];
   protected stepHelp?: string;
+  protected actionList?: string[];
+  protected targetObject?: string;
 
   constructor(protected client) {}
 
@@ -51,6 +53,14 @@ export abstract class BaseStep {
 
     if (this.stepHelp) {
       stepDefinition.setHelp(this.stepHelp);
+    }
+
+    if (this.actionList) {
+      stepDefinition.setActionList(this.actionList);
+    }
+
+    if (this.targetObject) {
+      stepDefinition.setTargetObject(this.targetObject);
     }
 
     this.expectedFields.forEach((field: Field) => {

--- a/src/proto/cog_pb.d.ts
+++ b/src/proto/cog_pb.d.ts
@@ -98,6 +98,14 @@ export class StepDefinition extends jspb.Message {
     setExpectedRecordsList(value: Array<RecordDefinition>): void;
     addExpectedRecords(value?: RecordDefinition, index?: number): RecordDefinition;
 
+    clearActionList(): void;
+    getActionList(): Array<string>;
+    setActionList(value: Array<string>): void;
+    addAction(value: string, index?: number): string;
+
+    getTargetObject(): string;
+    setTargetObject(value: string): void;
+
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): StepDefinition.AsObject;
@@ -118,6 +126,8 @@ export namespace StepDefinition {
         expression: string,
         expectedFieldsList: Array<FieldDefinition.AsObject>,
         expectedRecordsList: Array<RecordDefinition.AsObject>,
+        actionList: Array<string>,
+        targetObject: string,
     }
 
     export enum Type {

--- a/src/proto/cog_pb.js
+++ b/src/proto/cog_pb.js
@@ -732,7 +732,7 @@ proto.automaton.cog.CogManifest.prototype.setAuthHelpUrl = function(value) {
  * @private {!Array<number>}
  * @const
  */
-proto.automaton.cog.StepDefinition.repeatedFields_ = [4,7];
+proto.automaton.cog.StepDefinition.repeatedFields_ = [4,7,8];
 
 
 
@@ -773,7 +773,9 @@ proto.automaton.cog.StepDefinition.toObject = function(includeInstance, msg) {
     expectedFieldsList: jspb.Message.toObjectList(msg.getExpectedFieldsList(),
     proto.automaton.cog.FieldDefinition.toObject, includeInstance),
     expectedRecordsList: jspb.Message.toObjectList(msg.getExpectedRecordsList(),
-    proto.automaton.cog.RecordDefinition.toObject, includeInstance)
+    proto.automaton.cog.RecordDefinition.toObject, includeInstance),
+    actionList: (f = jspb.Message.getRepeatedField(msg, 8)) == null ? undefined : f,
+    targetObject: jspb.Message.getFieldWithDefault(msg, 9, "")
   };
 
   if (includeInstance) {
@@ -839,6 +841,14 @@ proto.automaton.cog.StepDefinition.deserializeBinaryFromReader = function(msg, r
       var value = new proto.automaton.cog.RecordDefinition;
       reader.readMessage(value,proto.automaton.cog.RecordDefinition.deserializeBinaryFromReader);
       msg.addExpectedRecords(value);
+      break;
+    case 8:
+      var value = /** @type {string} */ (reader.readString());
+      msg.addAction(value);
+      break;
+    case 9:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setTargetObject(value);
       break;
     default:
       reader.skipField();
@@ -918,6 +928,20 @@ proto.automaton.cog.StepDefinition.serializeBinaryToWriter = function(message, w
       7,
       f,
       proto.automaton.cog.RecordDefinition.serializeBinaryToWriter
+    );
+  }
+  f = message.getActionList();
+  if (f.length > 0) {
+    writer.writeRepeatedString(
+      8,
+      f
+    );
+  }
+  f = message.getTargetObject();
+  if (f.length > 0) {
+    writer.writeString(
+      9,
+      f
     );
   }
 };
@@ -1094,6 +1118,61 @@ proto.automaton.cog.StepDefinition.prototype.addExpectedRecords = function(opt_v
  */
 proto.automaton.cog.StepDefinition.prototype.clearExpectedRecordsList = function() {
   return this.setExpectedRecordsList([]);
+};
+
+
+/**
+ * repeated string action = 8;
+ * @return {!Array<string>}
+ */
+proto.automaton.cog.StepDefinition.prototype.getActionList = function() {
+  return /** @type {!Array<string>} */ (jspb.Message.getRepeatedField(this, 8));
+};
+
+
+/**
+ * @param {!Array<string>} value
+ * @return {!proto.automaton.cog.StepDefinition} returns this
+ */
+proto.automaton.cog.StepDefinition.prototype.setActionList = function(value) {
+  return jspb.Message.setField(this, 8, value || []);
+};
+
+
+/**
+ * @param {string} value
+ * @param {number=} opt_index
+ * @return {!proto.automaton.cog.StepDefinition} returns this
+ */
+proto.automaton.cog.StepDefinition.prototype.addAction = function(value, opt_index) {
+  return jspb.Message.addToRepeatedField(this, 8, value, opt_index);
+};
+
+
+/**
+ * Clears the list making it empty but non-null.
+ * @return {!proto.automaton.cog.StepDefinition} returns this
+ */
+proto.automaton.cog.StepDefinition.prototype.clearActionList = function() {
+  return this.setActionList([]);
+};
+
+
+/**
+ * optional string target_object = 9;
+ * @return {string}
+ */
+proto.automaton.cog.StepDefinition.prototype.getTargetObject = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 9, ""));
+};
+
+
+/**
+ * @param {string} value
+ * @return {!proto.automaton.cog.StepDefinition} returns this
+ */
+proto.automaton.cog.StepDefinition.prototype.setTargetObject = function(value) {
+  return jspb.Message.setProto3StringField(this, 9, value);
 };
 
 

--- a/src/steps/associate-web-activity.ts
+++ b/src/steps/associate-web-activity.ts
@@ -5,9 +5,11 @@ import { Step, FieldDefinition, StepDefinition, RecordDefinition } from '../prot
 
 export class AssociateWebActivityStep extends BaseStep implements StepInterface {
 
-  protected stepName: string = 'Associate Web Activity';
+  protected stepName: string = 'Associate web activity';
   protected stepExpression: string = 'associate web activity with munchkin cookie (?<munchkinCookie>.+) to marketo lead (?<email>.+\@.+\..+)';
   protected stepType: StepDefinition.Type = StepDefinition.Type.ACTION;
+  protected actionList: string[] = ['add'];
+  protected targetObject: string = 'Web Activity to Lead';
   protected expectedFields: Field[] = [
     {
       field: 'munchkinCookie',

--- a/src/steps/bulk-lead-create-or-update.ts
+++ b/src/steps/bulk-lead-create-or-update.ts
@@ -9,7 +9,7 @@ export class BulkCreateOrUpdateLeadByFieldStep extends BaseStep implements StepI
   protected stepExpression: string = 'bulk create or update marketo leads';
   protected stepType: StepDefinition.Type = StepDefinition.Type.ACTION;
   protected actionList: string[] = ['create', 'update'];
-  protected targetObject: string = 'Marketo Leads';
+  protected targetObject: string = 'Leads';
   protected expectedFields: Field[] = [
     {
       field: 'partitionId',

--- a/src/steps/bulk-lead-create-or-update.ts
+++ b/src/steps/bulk-lead-create-or-update.ts
@@ -5,9 +5,11 @@ import { Step, FieldDefinition, StepDefinition, RecordDefinition } from '../prot
 
 export class BulkCreateOrUpdateLeadByFieldStep extends BaseStep implements StepInterface {
 
-  protected stepName: string = 'Bulk Create or Update Marketo Leads';
+  protected stepName: string = 'Bulk create or update Marketo leads';
   protected stepExpression: string = 'bulk create or update marketo leads';
   protected stepType: StepDefinition.Type = StepDefinition.Type.ACTION;
+  protected actionList: string[] = ['create', 'update'];
+  protected targetObject: string = 'Marketo Leads';
   protected expectedFields: Field[] = [
     {
       field: 'partitionId',

--- a/src/steps/bulk-lead-field-equals.ts
+++ b/src/steps/bulk-lead-field-equals.ts
@@ -8,10 +8,12 @@ import { isNullOrUndefined } from 'util';
 
 export class BulkLeadFieldEqualsStep extends BaseStep implements StepInterface {
 
-  protected stepName: string = 'Check a field on multiple Marketo Leads';
+  protected stepName: string = 'Check a field on multiple Marketo leads';
   // tslint:disable-next-line:max-line-length
   protected stepExpression: string = 'the (?<field>[a-zA-Z0-9_-]+) field on marketo leads should (?<operator>be set|not be set|be less than|be greater than|be one of|be|contain|not be one of|not be|not contain|match|not match) ?(?<expectation>.+)?';
   protected stepType: StepDefinition.Type = StepDefinition.Type.VALIDATION;
+  protected actionList: string[] = ['check'];
+  protected targetObject: string = 'Marketo Leads';
   protected expectedFields: Field[] = [{
     field: 'leads',
     type: FieldDefinition.Type.MAP,

--- a/src/steps/bulk-lead-field-equals.ts
+++ b/src/steps/bulk-lead-field-equals.ts
@@ -13,7 +13,7 @@ export class BulkLeadFieldEqualsStep extends BaseStep implements StepInterface {
   protected stepExpression: string = 'the (?<field>[a-zA-Z0-9_-]+) field on marketo leads should (?<operator>be set|not be set|be less than|be greater than|be one of|be|contain|not be one of|not be|not contain|match|not match) ?(?<expectation>.+)?';
   protected stepType: StepDefinition.Type = StepDefinition.Type.VALIDATION;
   protected actionList: string[] = ['check'];
-  protected targetObject: string = 'Marketo Leads';
+  protected targetObject: string = 'Leads';
   protected expectedFields: Field[] = [{
     field: 'leads',
     type: FieldDefinition.Type.MAP,

--- a/src/steps/check-api-usage.ts
+++ b/src/steps/check-api-usage.ts
@@ -8,6 +8,8 @@ export class CheckApiUsageStep extends BaseStep implements StepInterface {
   protected stepName: string = 'Check daily Marketo API usage';
   protected stepExpression: string = 'there should be less than 90% usage of your daily API limit';
   protected stepType: StepDefinition.Type = StepDefinition.Type.VALIDATION;
+  protected actionList: string[] = ['check'];
+  protected targetObject: string = 'API Usage';
   protected expectedFields: Field[] = [{
     field: 'requestLimit',
     type: FieldDefinition.Type.NUMERIC,

--- a/src/steps/check-lead-activity-by-id.ts
+++ b/src/steps/check-lead-activity-by-id.ts
@@ -8,9 +8,11 @@ import * as moment from 'moment';
 
 export class CheckLeadActivityByIdStep extends BaseStep implements StepInterface {
 
-  protected stepName: string = 'Check a Marketo Lead\'s Activity by Id';
+  protected stepName: string = 'Check a Marketo lead\'s activity by id';
   protected stepExpression: string = 'there should (?<includes>not include|be|not be) an? (?<activityTypeIdOrName>.+) activity for marketo lead with id (?<id>.+) in the last (?<minutes>\\d+) minutes?';
   protected stepType: StepDefinition.Type = StepDefinition.Type.VALIDATION;
+  protected actionList: string[] = ['check'];
+  protected targetObject: string = 'Lead Activity by Id';
   protected expectedFields: Field[] = [{
     field: 'id',
     type: FieldDefinition.Type.STRING,

--- a/src/steps/check-lead-activity-by-id.ts
+++ b/src/steps/check-lead-activity-by-id.ts
@@ -8,11 +8,11 @@ import * as moment from 'moment';
 
 export class CheckLeadActivityByIdStep extends BaseStep implements StepInterface {
 
-  protected stepName: string = 'Check a Marketo lead\'s activity by id';
+  protected stepName: string = 'Check a Marketo lead\'s activity by ID';
   protected stepExpression: string = 'there should (?<includes>not include|be|not be) an? (?<activityTypeIdOrName>.+) activity for marketo lead with id (?<id>.+) in the last (?<minutes>\\d+) minutes?';
   protected stepType: StepDefinition.Type = StepDefinition.Type.VALIDATION;
   protected actionList: string[] = ['check'];
-  protected targetObject: string = 'Lead Activity by Id';
+  protected targetObject: string = 'Lead Activity by ID';
   protected expectedFields: Field[] = [{
     field: 'id',
     type: FieldDefinition.Type.STRING,

--- a/src/steps/check-lead-activity.ts
+++ b/src/steps/check-lead-activity.ts
@@ -8,9 +8,11 @@ import * as moment from 'moment';
 
 export class CheckLeadActivityStep extends BaseStep implements StepInterface {
 
-  protected stepName: string = 'Check a Marketo Lead\'s Activity';
+  protected stepName: string = 'Check a Marketo lead\'s activity';
   protected stepExpression: string = 'there should (?<includes>not include|be|not be) an? (?<activityTypeIdOrName>.+) activity for marketo lead (?<email>.+) in the last (?<minutes>\\d+) minutes?';
   protected stepType: StepDefinition.Type = StepDefinition.Type.VALIDATION;
+  protected actionList: string[] = ['check'];
+  protected targetObject: string = 'Lead Activity';
   protected expectedFields: Field[] = [{
     field: 'email', // to prevent breaking previous scenarios, this is will stay as email
     type: FieldDefinition.Type.STRING,

--- a/src/steps/custom-object-create-or-update.ts
+++ b/src/steps/custom-object-create-or-update.ts
@@ -6,9 +6,11 @@ import { Step, FieldDefinition, StepDefinition, RecordDefinition, StepRecord } f
 
 export class CreateOrUpdateCustomObjectStep extends BaseStep implements StepInterface {
 
-  protected stepName: string = 'Create or Update a Marketo Custom Object';
+  protected stepName: string = 'Create or update a Marketo custom object';
   protected stepExpression: string = 'create or update an? (?<name>.+) marketo custom object linked to lead (?<linkValue>.+)';
   protected stepType: StepDefinition.Type = StepDefinition.Type.ACTION;
+  protected actionList: string[] = ['create', 'update'];
+  protected targetObject: string = 'Custom Object';
   protected expectedFields: Field[] = [{
     field: 'name',
     type: FieldDefinition.Type.STRING,

--- a/src/steps/custom-object-delete.ts
+++ b/src/steps/custom-object-delete.ts
@@ -6,9 +6,11 @@ import { isNullOrUndefined } from 'util';
 
 export class DeleteCustomObjectStep extends BaseStep implements StepInterface {
 
-  protected stepName: string = 'Delete a Marketo Custom Object';
+  protected stepName: string = 'Delete a Marketo custom object';
   protected stepExpression: string = 'delete the (?<name>.+) marketo custom object linked to lead (?<linkValue>.+)';
   protected stepType: StepDefinition.Type = StepDefinition.Type.ACTION;
+  protected actionList: string[] = ['delete'];
+  protected targetObject: string = 'Custom Object';
   protected expectedFields: Field[] = [{
     field: 'name',
     type: FieldDefinition.Type.STRING,

--- a/src/steps/custom-object-field-equals.ts
+++ b/src/steps/custom-object-field-equals.ts
@@ -6,9 +6,11 @@ import { Step, FieldDefinition, StepDefinition, RecordDefinition, StepRecord } f
 
 export class CustomObjectFieldEqualsStep extends BaseStep implements StepInterface {
 
-  protected stepName: string = 'Check a field on a Marketo Custom Object';
+  protected stepName: string = 'Check a field on a Marketo custom object';
   protected stepExpression: string = 'the (?<field>[a-zA-Z0-9_-]+) field on the (?<name>.+) marketo custom object linked to lead (?<linkValue>.+) should (?<operator>be set|not be set|be less than|be greater than|be one of|be|contain|not be one of|not be|not contain|match|not match) ?(?<expectedValue>.+)?';
   protected stepType: StepDefinition.Type = StepDefinition.Type.VALIDATION;
+  protected actionList: string[] = ['check'];
+  protected targetObject: string = 'Custom Object';
   protected expectedFields: Field[] = [{
     field: 'name',
     type: FieldDefinition.Type.STRING,

--- a/src/steps/lead-by-id-field-equals.ts
+++ b/src/steps/lead-by-id-field-equals.ts
@@ -8,12 +8,12 @@ import { isNullOrUndefined } from 'util';
 
 export class LeadByIdFieldEqualsStep extends BaseStep implements StepInterface {
 
-  protected stepName: string = 'Check a field on a Marketo lead by id';
+  protected stepName: string = 'Check a field on a Marketo lead by ID';
   // tslint:disable-next-line:max-line-length
   protected stepExpression: string = 'the (?<field>[a-zA-Z0-9_-]+) field on marketo lead with id (?<leadId>.+) should (?<operator>be set|not be set|be less than|be greater than|be one of|be|contain|not be one of|not be|not contain|match|not match) ?(?<expectation>.+)?';
   protected stepType: StepDefinition.Type = StepDefinition.Type.VALIDATION;
   protected actionList: string[] = ['check'];
-  protected targetObject: string = 'Lead by Id';
+  protected targetObject: string = 'Lead by ID';
   protected expectedFields: Field[] = [{
     field: 'leadId',
     type: FieldDefinition.Type.STRING,

--- a/src/steps/lead-by-id-field-equals.ts
+++ b/src/steps/lead-by-id-field-equals.ts
@@ -8,10 +8,12 @@ import { isNullOrUndefined } from 'util';
 
 export class LeadByIdFieldEqualsStep extends BaseStep implements StepInterface {
 
-  protected stepName: string = 'Check a field on a Marketo Lead by Id';
+  protected stepName: string = 'Check a field on a Marketo lead by id';
   // tslint:disable-next-line:max-line-length
   protected stepExpression: string = 'the (?<field>[a-zA-Z0-9_-]+) field on marketo lead with id (?<leadId>.+) should (?<operator>be set|not be set|be less than|be greater than|be one of|be|contain|not be one of|not be|not contain|match|not match) ?(?<expectation>.+)?';
   protected stepType: StepDefinition.Type = StepDefinition.Type.VALIDATION;
+  protected actionList: string[] = ['check'];
+  protected targetObject: string = 'Lead by Id';
   protected expectedFields: Field[] = [{
     field: 'leadId',
     type: FieldDefinition.Type.STRING,

--- a/src/steps/lead-create-or-update.ts
+++ b/src/steps/lead-create-or-update.ts
@@ -5,9 +5,11 @@ import { Step, FieldDefinition, StepDefinition, RecordDefinition, StepRecord } f
 
 export class CreateOrUpdateLeadByFieldStep extends BaseStep implements StepInterface {
 
-  protected stepName: string = 'Create or update a Marketo Lead';
+  protected stepName: string = 'Create or update a Marketo lead';
   protected stepExpression: string = 'create or update a marketo lead';
   protected stepType: StepDefinition.Type = StepDefinition.Type.ACTION;
+  protected actionList: string[] = ['create', 'update'];
+  protected targetObject: string = 'Lead';
   protected expectedFields: Field[] = [
     {
       field: 'partitionId',

--- a/src/steps/lead-create.ts
+++ b/src/steps/lead-create.ts
@@ -5,9 +5,11 @@ import { Step, FieldDefinition, StepDefinition, RecordDefinition, StepRecord } f
 
 export class CreateLeadStep extends BaseStep implements StepInterface {
 
-  protected stepName: string = 'Create a Marketo Lead';
+  protected stepName: string = 'Create a Marketo lead';
   protected stepExpression: string = 'create a marketo lead';
   protected stepType: StepDefinition.Type = StepDefinition.Type.ACTION;
+  protected actionList: string[] = ['create'];
+  protected targetObject: string = 'Lead';
   protected expectedFields: Field[] = [
     {
       field: 'partitionId',

--- a/src/steps/lead-delete.ts
+++ b/src/steps/lead-delete.ts
@@ -5,9 +5,11 @@ import { Step, FieldDefinition, StepDefinition, RecordDefinition } from '../prot
 
 export class DeleteLeadStep extends BaseStep implements StepInterface {
 
-  protected stepName: string = 'Delete a Marketo Lead';
+  protected stepName: string = 'Delete a Marketo lead';
   protected stepExpression: string = 'delete the (?<email>.+) marketo lead';
   protected stepType: StepDefinition.Type = StepDefinition.Type.ACTION;
+  protected actionList: string[] = ['delete'];
+  protected targetObject: string = 'Lead';
   protected expectedFields: Field[] = [{
     field: 'email', // to prevent breaking previous scenarios, this is will stay as email
     type: FieldDefinition.Type.STRING,

--- a/src/steps/lead-discover.ts
+++ b/src/steps/lead-discover.ts
@@ -5,10 +5,12 @@ import { Step, FieldDefinition, StepDefinition, RecordDefinition, StepRecord } f
 
 export class DiscoverLead extends BaseStep implements StepInterface {
 
-  protected stepName: string = 'Discover fields on a Marketo Lead';
+  protected stepName: string = 'Discover fields on a Marketo lead';
   // tslint:disable-next-line:max-line-length
   protected stepExpression: string = 'discover fields on marketo lead (?<email>.+)';
   protected stepType: StepDefinition.Type = StepDefinition.Type.ACTION;
+  protected actionList: string[] = ['discover'];
+  protected targetObject: string = 'Lead';
   protected expectedFields: Field[] = [{
     field: 'email', // to prevent breaking previous scenarios, this is will stay as email
     type: FieldDefinition.Type.STRING,

--- a/src/steps/lead-field-equals.ts
+++ b/src/steps/lead-field-equals.ts
@@ -8,10 +8,12 @@ import { isNullOrUndefined } from 'util';
 
 export class LeadFieldEqualsStep extends BaseStep implements StepInterface {
 
-  protected stepName: string = 'Check a field on a Marketo Lead';
+  protected stepName: string = 'Check a field on a Marketo lead';
   // tslint:disable-next-line:max-line-length
   protected stepExpression: string = 'the (?<field>[a-zA-Z0-9_-]+) field on marketo lead (?<email>.+\@.+\..+) should (?<operator>be set|not be set|be less than|be greater than|be one of|be|contain|not be one of|not be|not contain|match|not match) ?(?<expectation>.+)?';
   protected stepType: StepDefinition.Type = StepDefinition.Type.VALIDATION;
+  protected actionList: string[] = ['check'];
+  protected targetObject: string = 'Lead';
   protected expectedFields: Field[] = [{
     field: 'email', // to prevent breaking previous scenarios, this is will stay as email
     type: FieldDefinition.Type.STRING,

--- a/src/steps/lead-merge.ts
+++ b/src/steps/lead-merge.ts
@@ -12,7 +12,7 @@ export class MergeLeadsStep extends BaseStep implements StepInterface {
   // tslint:disable-next-line:max-line-length
   protected stepExpression: string = 'merge marketo lead (?<losingEmail>.+\@.+\..+) into marketo lead (?<winningEmail>.+\@.+\..+)';
   protected stepType: StepDefinition.Type = StepDefinition.Type.ACTION;
-  protected actionList: string[] = ['misc'];
+  protected actionList: string[] = [];
   protected targetObject: string = 'Merge Leads';
   protected expectedFields: Field[] = [{
     field: 'losingEmail',

--- a/src/steps/lead-merge.ts
+++ b/src/steps/lead-merge.ts
@@ -8,10 +8,12 @@ import { isNullOrUndefined } from 'util';
 
 export class MergeLeadsStep extends BaseStep implements StepInterface {
 
-  protected stepName: string = 'Merge Marketo Leads';
+  protected stepName: string = 'Merge Marketo leads';
   // tslint:disable-next-line:max-line-length
   protected stepExpression: string = 'merge marketo lead (?<losingEmail>.+\@.+\..+) into marketo lead (?<winningEmail>.+\@.+\..+)';
   protected stepType: StepDefinition.Type = StepDefinition.Type.ACTION;
+  protected actionList: string[] = ['misc'];
+  protected targetObject: string = 'Merge Leads';
   protected expectedFields: Field[] = [{
     field: 'losingEmail',
     type: FieldDefinition.Type.STRING,

--- a/src/steps/lead-update.ts
+++ b/src/steps/lead-update.ts
@@ -5,9 +5,11 @@ import { Step, FieldDefinition, StepDefinition, RecordDefinition, StepRecord } f
 
 export class UpdateLeadStep extends BaseStep implements StepInterface {
 
-  protected stepName: string = 'Update a Marketo Lead';
+  protected stepName: string = 'Update a Marketo lead';
   protected stepExpression: string = 'update a marketo lead';
   protected stepType: StepDefinition.Type = StepDefinition.Type.ACTION;
+  protected actionList: string[] = ['update'];
+  protected targetObject: string = 'Lead';
   protected expectedFields: Field[] = [
     {
       field: 'partitionId',

--- a/src/steps/program-members/bulk-program-member-add-or-remove.ts
+++ b/src/steps/program-members/bulk-program-member-add-or-remove.ts
@@ -5,9 +5,11 @@ import { Step, FieldDefinition, StepDefinition, RecordDefinition } from '../../p
 
 export class BulkAddOrRemoveProgramMemberStep extends BaseStep implements StepInterface {
 
-  protected stepName: string = 'Bulk Add or Remove Marketo Program Members';
+  protected stepName: string = 'Bulk add or remove Marketo program members';
   protected stepExpression: string = 'bulk add or remove marketo program members';
   protected stepType: StepDefinition.Type = StepDefinition.Type.ACTION;
+  protected actionList: string[] = ['create', 'delete'];
+  protected targetObject: string = 'Program Member';
   protected expectedFields: Field[] = [
     {
       field: 'partitionId',

--- a/src/steps/program-members/program-member-add-or-remove.ts
+++ b/src/steps/program-members/program-member-add-or-remove.ts
@@ -5,9 +5,11 @@ import { Step, FieldDefinition, StepDefinition, RecordDefinition } from '../../p
 
 export class AddOrRemoveProgramMemberStep extends BaseStep implements StepInterface {
 
-  protected stepName: string = 'Add or Remove Marketo Program Members';
+  protected stepName: string = 'Add or remove Marketo program members';
   protected stepExpression: string = 'add or remove marketo program members';
   protected stepType: StepDefinition.Type = StepDefinition.Type.ACTION;
+  protected actionList: string[] = ['add', 'remove'];
+  protected targetObject: string = 'Program Member';
   protected expectedFields: Field[] = [
     {
       field: 'partitionId',

--- a/src/steps/program-members/program-member-count.ts
+++ b/src/steps/program-members/program-member-count.ts
@@ -8,10 +8,12 @@ import { isNullOrUndefined } from 'util';
 
 export class ProgramMemberCountStep extends BaseStep implements StepInterface {
 
-  protected stepName: string = 'Count a Marketo Program';
+  protected stepName: string = 'Count a Marketo program';
   // tslint:disable-next-line:max-line-length
   protected stepExpression: string = 'check the number of members from marketo program (?<programName>.+)';
   protected stepType: StepDefinition.Type = StepDefinition.Type.VALIDATION;
+  protected actionList: string[] = ['check'];
+  protected targetObject: string = 'Program Member Count';
   protected expectedFields: Field[] = [{
     field: 'programName',
     type: FieldDefinition.Type.STRING,

--- a/src/steps/program-members/program-member-field-equals.ts
+++ b/src/steps/program-members/program-member-field-equals.ts
@@ -8,10 +8,12 @@ import { isNullOrUndefined } from 'util';
 
 export class ProgramMemberFieldEqualsStep extends BaseStep implements StepInterface {
 
-  protected stepName: string = 'Check a field on a Marketo Program Member';
+  protected stepName: string = 'Check a field on a Marketo program member';
   // tslint:disable-next-line:max-line-length
   protected stepExpression: string = 'the (?<field>[a-zA-Z0-9_-]+) field on marketo member (?<email>.+) from program (?<programName>.+) should (?<operator>be set|not be set|be less than|be greater than|be one of|be|contain|not be one of|not be|not contain|match|not match) ?(?<expectation>.+)?';
   protected stepType: StepDefinition.Type = StepDefinition.Type.VALIDATION;
+  protected actionList: string[] = ['check'];
+  protected targetObject: string = 'Program Member';
   protected expectedFields: Field[] = [{
     field: 'programName',
     type: FieldDefinition.Type.STRING,

--- a/src/steps/programs/program-create-cost.ts
+++ b/src/steps/programs/program-create-cost.ts
@@ -6,9 +6,11 @@ import { Step, FieldDefinition, StepDefinition, RecordDefinition } from '../../p
 
 export class CreateProgramCostStep extends BaseStep implements StepInterface {
 
-  protected stepName: string = 'Create Cost for Marketo Program';
+  protected stepName: string = 'Create cost for Marketo program';
   protected stepExpression: string = 'create cost for marketo program';
   protected stepType: StepDefinition.Type = StepDefinition.Type.ACTION;
+  protected actionList: string[] = ['create'];
+  protected targetObject: string = 'Program Cost';
   protected expectedFields: Field[] = [
     {
       field: 'name',

--- a/src/steps/programs/program-create.ts
+++ b/src/steps/programs/program-create.ts
@@ -5,9 +5,11 @@ import { Step, FieldDefinition, StepDefinition, RecordDefinition } from '../../p
 
 export class CreateProgramStep extends BaseStep implements StepInterface {
 
-  protected stepName: string = 'Create a Marketo Program';
+  protected stepName: string = 'Create a Marketo program';
   protected stepExpression: string = 'create a marketo program';
   protected stepType: StepDefinition.Type = StepDefinition.Type.ACTION;
+  protected actionList: string[] = ['create'];
+  protected targetObject: string = 'Program';
   protected expectedFields: Field[] = [
     {
       field: 'workspace',

--- a/src/steps/programs/program-delete.ts
+++ b/src/steps/programs/program-delete.ts
@@ -5,9 +5,11 @@ import { Step, FieldDefinition, StepDefinition, RecordDefinition } from '../../p
 
 export class DeleteProgramStep extends BaseStep implements StepInterface {
 
-  protected stepName: string = 'Delete a Marketo Program';
+  protected stepName: string = 'Delete a Marketo program';
   protected stepExpression: string = 'delete the (?<name>.+) marketo program';
   protected stepType: StepDefinition.Type = StepDefinition.Type.ACTION;
+  protected actionList: string[] = ['delete'];
+  protected targetObject: string = 'Program';
   protected expectedFields: Field[] = [{
     field: 'name',
     type: FieldDefinition.Type.STRING,

--- a/src/steps/programs/program-field-equals.ts
+++ b/src/steps/programs/program-field-equals.ts
@@ -8,10 +8,12 @@ import { isNullOrUndefined } from 'util';
 
 export class ProgramFieldEqualsStep extends BaseStep implements StepInterface {
 
-  protected stepName: string = 'Check a field on a Marketo Program';
+  protected stepName: string = 'Check a field on a Marketo program';
   // tslint:disable-next-line:max-line-length
   protected stepExpression: string = 'the (?<field>[a-zA-Z0-9_-]+) field on marketo program (?<name>.+) should (?<operator>be set|not be set|be less than|be greater than|be one of|be|contain|not be one of|not be|not contain|match|not match) ?(?<expectation>.+)?';
   protected stepType: StepDefinition.Type = StepDefinition.Type.VALIDATION;
+  protected actionList: string[] = ['check'];
+  protected targetObject: string = 'Program';
   protected expectedFields: Field[] = [{
     field: 'name',
     type: FieldDefinition.Type.STRING,

--- a/src/steps/programs/program-update.ts
+++ b/src/steps/programs/program-update.ts
@@ -5,9 +5,11 @@ import { Step, FieldDefinition, StepDefinition, RecordDefinition } from '../../p
 
 export class UpdateProgramStep extends BaseStep implements StepInterface {
 
-  protected stepName: string = 'Update a Marketo Program';
+  protected stepName: string = 'Update a Marketo program';
   protected stepExpression: string = 'update a marketo program';
   protected stepType: StepDefinition.Type = StepDefinition.Type.ACTION;
+  protected actionList: string[] = ['update'];
+  protected targetObject: string = 'Program';
   protected expectedFields: Field[] = [
     {
       field: 'id',

--- a/src/steps/send-sample-email.ts
+++ b/src/steps/send-sample-email.ts
@@ -5,9 +5,11 @@ import { Step, FieldDefinition, StepDefinition, RecordDefinition } from '../prot
 
 export class SendSampleEmailStep extends BaseStep implements StepInterface {
 
-  protected stepName: string = 'Send Sample Email';
+  protected stepName: string = 'Send sample email';
   protected stepExpression: string = 'send a sample email to (?<emailAddress>.+\@.+\..+)';
   protected stepType: StepDefinition.Type = StepDefinition.Type.ACTION;
+  protected actionList: string[] = ['misc'];
+  protected targetObject: string = 'Send Email';
   protected expectedFields: Field[] = [
     {
       field: 'workspace',

--- a/src/steps/send-sample-email.ts
+++ b/src/steps/send-sample-email.ts
@@ -8,7 +8,7 @@ export class SendSampleEmailStep extends BaseStep implements StepInterface {
   protected stepName: string = 'Send sample email';
   protected stepExpression: string = 'send a sample email to (?<emailAddress>.+\@.+\..+)';
   protected stepType: StepDefinition.Type = StepDefinition.Type.ACTION;
-  protected actionList: string[] = ['misc'];
+  protected actionList: string[] = [];
   protected targetObject: string = 'Send Email';
   protected expectedFields: Field[] = [
     {

--- a/src/steps/smart-campaign-add-lead.ts
+++ b/src/steps/smart-campaign-add-lead.ts
@@ -5,9 +5,11 @@ import { Step, FieldDefinition, StepDefinition, RecordDefinition, StepRecord } f
 
 export class AddLeadToSmartCampaignStep extends BaseStep implements StepInterface {
 
-  protected stepName: string = 'Add Marketo Lead to Smart Campaign';
+  protected stepName: string = 'Add Marketo lead to smart campaign';
   protected stepExpression: string = 'add the (?<email>.+) marketo lead to smart campaign (?<campaign>.+)';
   protected stepType: StepDefinition.Type = StepDefinition.Type.ACTION;
+  protected actionList: string[] = ['add'];
+  protected targetObject: string = 'Lead to Smart Campaign';
   protected expectedFields: Field[] = [{
     field: 'email',
     type: FieldDefinition.Type.STRING,

--- a/src/steps/static-lists/static-list-add-lead.ts
+++ b/src/steps/static-lists/static-list-add-lead.ts
@@ -5,9 +5,11 @@ import { Step, FieldDefinition, StepDefinition, RecordDefinition, StepRecord } f
 
 export class AddLeadToStaticListStep extends BaseStep implements StepInterface {
 
-  protected stepName: string = 'Add Marketo Leads to Static List';
+  protected stepName: string = 'Add Marketo leads to static list';
   protected stepExpression: string = 'add marketo leads to static list (?<staticListName>.+)';
   protected stepType: StepDefinition.Type = StepDefinition.Type.ACTION;
+  protected actionList: string[] = ['add'];
+  protected targetObject: string = 'Leads to Static List';
   protected expectedFields: Field[] = [{
     field: 'staticListName',
     type: FieldDefinition.Type.STRING,

--- a/src/steps/static-lists/static-list-member-count.ts
+++ b/src/steps/static-lists/static-list-member-count.ts
@@ -7,10 +7,12 @@ import { baseOperators } from '../../client/constants/operators';
 
 export class StaticListMemberCountStep extends BaseStep implements StepInterface {
 
-  protected stepName: string = 'Count a Marketo Static List';
+  protected stepName: string = 'Count a Marketo static list';
   // tslint:disable-next-line:max-line-length
   protected stepExpression: string = 'check the number of members from marketo static list (?<staticListName>.+)';
   protected stepType: StepDefinition.Type = StepDefinition.Type.VALIDATION;
+  protected actionList: string[] = ['check'];
+  protected targetObject: string = 'Static List Count';
   protected expectedFields: Field[] = [{
     field: 'staticListName',
     type: FieldDefinition.Type.STRING,

--- a/src/steps/static-lists/static-list-remove-lead.ts
+++ b/src/steps/static-lists/static-list-remove-lead.ts
@@ -5,9 +5,11 @@ import { Step, FieldDefinition, StepDefinition, RecordDefinition } from '../../p
 
 export class RemoveLeadToStaticListStep extends BaseStep implements StepInterface {
 
-  protected stepName: string = 'Remove Marketo Leads to Static List';
-  protected stepExpression: string = 'remove marketo leads to static list (?<staticListName>.+)';
+  protected stepName: string = 'Remove Marketo leads from static list';
+  protected stepExpression: string = 'remove marketo leads from static list (?<staticListName>.+)';
   protected stepType: StepDefinition.Type = StepDefinition.Type.ACTION;
+  protected actionList: string[] = ['remove'];
+  protected targetObject: string = 'Leads from Static List';
   protected expectedFields: Field[] = [{
     field: 'staticListName',
     type: FieldDefinition.Type.STRING,

--- a/test/steps/associate-web-activity.ts
+++ b/test/steps/associate-web-activity.ts
@@ -26,7 +26,7 @@ describe('AssociateWebActivityStep', () => {
   it('should return expected step metadata', () => {
     const stepDef: StepDefinition = stepUnderTest.getDefinition();
     expect(stepDef.getStepId()).to.equal('AssociateWebActivityStep');
-    expect(stepDef.getName()).to.equal('Associate Web Activity');
+    expect(stepDef.getName()).to.equal('Associate web activity');
     expect(stepDef.getExpression()).to.equal('associate web activity with munchkin cookie (?<munchkinCookie>.+) to marketo lead (?<email>.+\@.+\..+)');
     expect(stepDef.getType()).to.equal(StepDefinition.Type.ACTION);
   });

--- a/test/steps/bulk-lead-create-or-update.ts
+++ b/test/steps/bulk-lead-create-or-update.ts
@@ -25,7 +25,7 @@ describe('BulkCreateOrUpdateLeadByFieldStep', () => {
   it('should return expected step metadata', () => {
     const stepDef: StepDefinition = stepUnderTest.getDefinition();
     expect(stepDef.getStepId()).to.equal('BulkCreateOrUpdateLeadByFieldStep');
-    expect(stepDef.getName()).to.equal('Bulk Create or Update Marketo Leads');
+    expect(stepDef.getName()).to.equal('Bulk create or update Marketo leads');
     expect(stepDef.getExpression()).to.equal('bulk create or update marketo leads');
     expect(stepDef.getType()).to.equal(StepDefinition.Type.ACTION);
   });

--- a/test/steps/bulk-lead-field-equals.ts
+++ b/test/steps/bulk-lead-field-equals.ts
@@ -25,7 +25,7 @@ describe('BulkLeadFieldEqualsStep', () => {
   it('should return expected step metadata', () => {
     const stepDef: StepDefinition = stepUnderTest.getDefinition();
     expect(stepDef.getStepId()).to.equal('BulkLeadFieldEqualsStep');
-    expect(stepDef.getName()).to.equal('Check a field on multiple Marketo Leads');
+    expect(stepDef.getName()).to.equal('Check a field on multiple Marketo leads');
     expect(stepDef.getExpression()).to.equal('the (?<field>[a-zA-Z0-9_-]+) field on marketo leads should (?<operator>be set|not be set|be less than|be greater than|be one of|be|contain|not be one of|not be|not contain|match|not match) ?(?<expectation>.+)?');
     expect(stepDef.getType()).to.equal(StepDefinition.Type.VALIDATION);
   });

--- a/test/steps/check-lead-activity-by-id.ts
+++ b/test/steps/check-lead-activity-by-id.ts
@@ -28,7 +28,7 @@ describe('CheckLeadActivityByIdStep', () => {
   it('should return expected step metadata', () => {
     const stepDef: StepDefinition = stepUnderTest.getDefinition();
     expect(stepDef.getStepId()).to.equal('CheckLeadActivityByIdStep');
-    expect(stepDef.getName()).to.equal('Check a Marketo lead\'s activity by id');
+    expect(stepDef.getName()).to.equal('Check a Marketo lead\'s activity by ID');
     expect(stepDef.getExpression()).to.equal('there should (?<includes>not include|be|not be) an? (?<activityTypeIdOrName>.+) activity for marketo lead with id (?<id>.+) in the last (?<minutes>\\d+) minutes?');
     expect(stepDef.getType()).to.equal(StepDefinition.Type.VALIDATION);
   });

--- a/test/steps/check-lead-activity-by-id.ts
+++ b/test/steps/check-lead-activity-by-id.ts
@@ -28,7 +28,7 @@ describe('CheckLeadActivityByIdStep', () => {
   it('should return expected step metadata', () => {
     const stepDef: StepDefinition = stepUnderTest.getDefinition();
     expect(stepDef.getStepId()).to.equal('CheckLeadActivityByIdStep');
-    expect(stepDef.getName()).to.equal('Check a Marketo Lead\'s Activity by Id');
+    expect(stepDef.getName()).to.equal('Check a Marketo lead\'s activity by id');
     expect(stepDef.getExpression()).to.equal('there should (?<includes>not include|be|not be) an? (?<activityTypeIdOrName>.+) activity for marketo lead with id (?<id>.+) in the last (?<minutes>\\d+) minutes?');
     expect(stepDef.getType()).to.equal(StepDefinition.Type.VALIDATION);
   });

--- a/test/steps/check-lead-activity.ts
+++ b/test/steps/check-lead-activity.ts
@@ -29,7 +29,7 @@ describe('CheckLeadActivityStep', () => {
   it('should return expected step metadata', () => {
     const stepDef: StepDefinition = stepUnderTest.getDefinition();
     expect(stepDef.getStepId()).to.equal('CheckLeadActivityStep');
-    expect(stepDef.getName()).to.equal('Check a Marketo Lead\'s Activity');
+    expect(stepDef.getName()).to.equal('Check a Marketo lead\'s activity');
     expect(stepDef.getExpression()).to.equal('there should (?<includes>not include|be|not be) an? (?<activityTypeIdOrName>.+) activity for marketo lead (?<email>.+) in the last (?<minutes>\\d+) minutes?');
     expect(stepDef.getType()).to.equal(StepDefinition.Type.VALIDATION);
   });

--- a/test/steps/custom-object-create-or-update.ts
+++ b/test/steps/custom-object-create-or-update.ts
@@ -28,7 +28,7 @@ describe('CreateOrUpdateCustomObject', () => {
   it('should return expected step metadata', () => {
     const stepDef: StepDefinition = stepUnderTest.getDefinition();
     expect(stepDef.getStepId()).to.equal('CreateOrUpdateCustomObjectStep');
-    expect(stepDef.getName()).to.equal('Create or Update a Marketo Custom Object');
+    expect(stepDef.getName()).to.equal('Create or update a Marketo custom object');
     expect(stepDef.getExpression()).to.equal('create or update an? (?<name>.+) marketo custom object linked to lead (?<linkValue>.+)');
     expect(stepDef.getType()).to.equal(StepDefinition.Type.ACTION);
   });

--- a/test/steps/custom-object-delete.ts
+++ b/test/steps/custom-object-delete.ts
@@ -29,7 +29,7 @@ describe('DeleteCustomObject', () => {
   it('should return expected step metadata', () => {
     const stepDef: StepDefinition = stepUnderTest.getDefinition();
     expect(stepDef.getStepId()).to.equal('DeleteCustomObjectStep');
-    expect(stepDef.getName()).to.equal('Delete a Marketo Custom Object');
+    expect(stepDef.getName()).to.equal('Delete a Marketo custom object');
     expect(stepDef.getExpression()).to.equal('delete the (?<name>.+) marketo custom object linked to lead (?<linkValue>.+)');
     expect(stepDef.getType()).to.equal(StepDefinition.Type.ACTION);
   });

--- a/test/steps/custom-object-field-equals.ts
+++ b/test/steps/custom-object-field-equals.ts
@@ -28,7 +28,7 @@ describe('CustomObjectFieldEquals', () => {
   it('should return expected step metadata', () => {
     const stepDef: StepDefinition = stepUnderTest.getDefinition();
     expect(stepDef.getStepId()).to.equal('CustomObjectFieldEqualsStep');
-    expect(stepDef.getName()).to.equal('Check a field on a Marketo Custom Object');
+    expect(stepDef.getName()).to.equal('Check a field on a Marketo custom object');
     expect(stepDef.getExpression()).to.equal('the (?<field>[a-zA-Z0-9_-]+) field on the (?<name>.+) marketo custom object linked to lead (?<linkValue>.+) should (?<operator>be set|not be set|be less than|be greater than|be one of|be|contain|not be one of|not be|not contain|match|not match) ?(?<expectedValue>.+)?');
     expect(stepDef.getType()).to.equal(StepDefinition.Type.VALIDATION);
   });

--- a/test/steps/lead-by-id-field-equals.ts
+++ b/test/steps/lead-by-id-field-equals.ts
@@ -25,7 +25,7 @@ describe('LeadByIdFieldEqualsStep', () => {
   it('should return expected step metadata', () => {
     const stepDef: StepDefinition = stepUnderTest.getDefinition();
     expect(stepDef.getStepId()).to.equal('LeadByIdFieldEqualsStep');
-    expect(stepDef.getName()).to.equal('Check a field on a Marketo Lead by Id');
+    expect(stepDef.getName()).to.equal('Check a field on a Marketo lead by id');
     expect(stepDef.getExpression()).to.equal('the (?<field>[a-zA-Z0-9_-]+) field on marketo lead with id (?<leadId>.+) should (?<operator>be set|not be set|be less than|be greater than|be one of|be|contain|not be one of|not be|not contain|match|not match) ?(?<expectation>.+)?');
     expect(stepDef.getType()).to.equal(StepDefinition.Type.VALIDATION);
   });

--- a/test/steps/lead-by-id-field-equals.ts
+++ b/test/steps/lead-by-id-field-equals.ts
@@ -25,7 +25,7 @@ describe('LeadByIdFieldEqualsStep', () => {
   it('should return expected step metadata', () => {
     const stepDef: StepDefinition = stepUnderTest.getDefinition();
     expect(stepDef.getStepId()).to.equal('LeadByIdFieldEqualsStep');
-    expect(stepDef.getName()).to.equal('Check a field on a Marketo lead by id');
+    expect(stepDef.getName()).to.equal('Check a field on a Marketo lead by ID');
     expect(stepDef.getExpression()).to.equal('the (?<field>[a-zA-Z0-9_-]+) field on marketo lead with id (?<leadId>.+) should (?<operator>be set|not be set|be less than|be greater than|be one of|be|contain|not be one of|not be|not contain|match|not match) ?(?<expectation>.+)?');
     expect(stepDef.getType()).to.equal(StepDefinition.Type.VALIDATION);
   });

--- a/test/steps/lead-create-or-update.ts
+++ b/test/steps/lead-create-or-update.ts
@@ -26,7 +26,7 @@ describe('CreateOrUpdateLeadByFieldStep', () => {
   it('should return expected step metadata', () => {
     const stepDef: StepDefinition = stepUnderTest.getDefinition();
     expect(stepDef.getStepId()).to.equal('CreateOrUpdateLeadByFieldStep');
-    expect(stepDef.getName()).to.equal('Create or update a Marketo Lead');
+    expect(stepDef.getName()).to.equal('Create or update a Marketo lead');
     expect(stepDef.getExpression()).to.equal('create or update a marketo lead');
     expect(stepDef.getType()).to.equal(StepDefinition.Type.ACTION);
   });

--- a/test/steps/lead-create.ts
+++ b/test/steps/lead-create.ts
@@ -26,7 +26,7 @@ describe('CreateLeadStep', () => {
   it('should return expected step metadata', () => {
     const stepDef: StepDefinition = stepUnderTest.getDefinition();
     expect(stepDef.getStepId()).to.equal('CreateLeadStep');
-    expect(stepDef.getName()).to.equal('Create a Marketo Lead');
+    expect(stepDef.getName()).to.equal('Create a Marketo lead');
     expect(stepDef.getExpression()).to.equal('create a marketo lead');
     expect(stepDef.getType()).to.equal(StepDefinition.Type.ACTION);
   });

--- a/test/steps/lead-delete.ts
+++ b/test/steps/lead-delete.ts
@@ -26,7 +26,7 @@ describe('DeleteLeadStep', () => {
   it('should return expected step metadata', () => {
     const stepDef: StepDefinition = stepUnderTest.getDefinition();
     expect(stepDef.getStepId()).to.equal('DeleteLeadStep');
-    expect(stepDef.getName()).to.equal('Delete a Marketo Lead');
+    expect(stepDef.getName()).to.equal('Delete a Marketo lead');
     expect(stepDef.getExpression()).to.equal('delete the (?<email>.+) marketo lead');
     expect(stepDef.getType()).to.equal(StepDefinition.Type.ACTION);
   });

--- a/test/steps/lead-discover.ts
+++ b/test/steps/lead-discover.ts
@@ -25,7 +25,7 @@ describe('DiscoverLeadStep', () => {
   it('should return expected step metadata', () => {
     const stepDef: StepDefinition = stepUnderTest.getDefinition();
     expect(stepDef.getStepId()).to.equal('DiscoverLead');
-    expect(stepDef.getName()).to.equal('Discover fields on a Marketo Lead');
+    expect(stepDef.getName()).to.equal('Discover fields on a Marketo lead');
     expect(stepDef.getExpression()).to.equal('discover fields on marketo lead (?<email>.+)');
     expect(stepDef.getType()).to.equal(StepDefinition.Type.ACTION);
   });

--- a/test/steps/lead-field-equals.ts
+++ b/test/steps/lead-field-equals.ts
@@ -27,7 +27,7 @@ describe('LeadFieldEqualsStep', () => {
     it('should return expected step metadata', () => {
       const stepDef: StepDefinition = stepUnderTest.getDefinition();
       expect(stepDef.getStepId()).to.equal('LeadFieldEqualsStep');
-      expect(stepDef.getName()).to.equal('Check a field on a Marketo Lead');
+      expect(stepDef.getName()).to.equal('Check a field on a Marketo lead');
       expect(stepDef.getExpression()).to.equal('the (?<field>[a-zA-Z0-9_-]+) field on marketo lead (?<email>.+@.+..+) should (?<operator>be set|not be set|be less than|be greater than|be one of|be|contain|not be one of|not be|not contain|match|not match) ?(?<expectation>.+)?');
       expect(stepDef.getType()).to.equal(StepDefinition.Type.VALIDATION);
     });

--- a/test/steps/lead-merge.ts
+++ b/test/steps/lead-merge.ts
@@ -26,7 +26,7 @@ describe('MergeLeadsStep', () => {
   it('should return expected step metadata', () => {
     const stepDef: StepDefinition = stepUnderTest.getDefinition();
     expect(stepDef.getStepId()).to.equal('MergeLeadsStep');
-    expect(stepDef.getName()).to.equal('Merge Marketo Leads');
+    expect(stepDef.getName()).to.equal('Merge Marketo leads');
     expect(stepDef.getExpression()).to.equal('merge marketo lead (?<losingEmail>.+\@.+\..+) into marketo lead (?<winningEmail>.+\@.+\..+)');
     expect(stepDef.getType()).to.equal(StepDefinition.Type.ACTION);
   });

--- a/test/steps/lead-update.ts
+++ b/test/steps/lead-update.ts
@@ -27,7 +27,7 @@ describe('UpdateLeadStep', () => {
   it('should return expected step metadata', () => {
     const stepDef: StepDefinition = stepUnderTest.getDefinition();
     expect(stepDef.getStepId()).to.equal('UpdateLeadStep');
-    expect(stepDef.getName()).to.equal('Update a Marketo Lead');
+    expect(stepDef.getName()).to.equal('Update a Marketo lead');
     expect(stepDef.getExpression()).to.equal('update a marketo lead');
     expect(stepDef.getType()).to.equal(StepDefinition.Type.ACTION);
   });

--- a/test/steps/program-members/bulk-program-member-add-or-remove.ts
+++ b/test/steps/program-members/bulk-program-member-add-or-remove.ts
@@ -25,7 +25,7 @@ describe('BulkAddOrRemoveProgramMemberStep', () => {
   it('should return expected step metadata', () => {
     const stepDef: StepDefinition = stepUnderTest.getDefinition();
     expect(stepDef.getStepId()).to.equal('BulkAddOrRemoveProgramMemberStep');
-    expect(stepDef.getName()).to.equal('Bulk Add or Remove Marketo Program Members');
+    expect(stepDef.getName()).to.equal('Bulk add or remove Marketo program members');
     expect(stepDef.getExpression()).to.equal('bulk add or remove marketo program members');
     expect(stepDef.getType()).to.equal(StepDefinition.Type.ACTION);
   });

--- a/test/steps/program-members/program-member-add-or-remove.ts
+++ b/test/steps/program-members/program-member-add-or-remove.ts
@@ -28,7 +28,7 @@ describe('AddOrRemoveProgramMemberStep', () => {
   it('should return expected step metadata', () => {
     const stepDef: StepDefinition = stepUnderTest.getDefinition();
     expect(stepDef.getStepId()).to.equal('AddOrRemoveProgramMemberStep');
-    expect(stepDef.getName()).to.equal('Add or Remove Marketo Program Members');
+    expect(stepDef.getName()).to.equal('Add or remove Marketo program members');
     expect(stepDef.getExpression()).to.equal('add or remove marketo program members');
     expect(stepDef.getType()).to.equal(StepDefinition.Type.ACTION);
   });

--- a/test/steps/program-members/program-member-count.ts
+++ b/test/steps/program-members/program-member-count.ts
@@ -27,7 +27,7 @@ describe('ProgramMemberCountStep', () => {
   it('should return expected step metadata', () => {
     const stepDef: StepDefinition = stepUnderTest.getDefinition();
     expect(stepDef.getStepId()).to.equal('ProgramMemberCountStep');
-    expect(stepDef.getName()).to.equal('Count a Marketo Program');
+    expect(stepDef.getName()).to.equal('Count a Marketo program');
     expect(stepDef.getExpression()).to.equal('check the number of members from marketo program (?<programName>.+)');
     expect(stepDef.getType()).to.equal(StepDefinition.Type.VALIDATION);
   });

--- a/test/steps/program-members/program-member-field-equals.ts
+++ b/test/steps/program-members/program-member-field-equals.ts
@@ -56,7 +56,7 @@ describe('ProgramMemberFieldEqualsStep', () => {
   it('should return expected step metadata', () => {
     const stepDef: StepDefinition = stepUnderTest.getDefinition();
     expect(stepDef.getStepId()).to.equal('ProgramMemberFieldEqualsStep');
-    expect(stepDef.getName()).to.equal('Check a field on a Marketo Program Member');
+    expect(stepDef.getName()).to.equal('Check a field on a Marketo program member');
     expect(stepDef.getExpression()).to.equal('the (?<field>[a-zA-Z0-9_-]+) field on marketo member (?<email>.+) from program (?<programName>.+) should (?<operator>be set|not be set|be less than|be greater than|be one of|be|contain|not be one of|not be|not contain|match|not match) ?(?<expectation>.+)?');
     expect(stepDef.getType()).to.equal(StepDefinition.Type.VALIDATION);
   });

--- a/test/steps/programs/program-create-cost.ts
+++ b/test/steps/programs/program-create-cost.ts
@@ -26,7 +26,7 @@ describe('CreateProgramCostStep', () => {
   it('should return expected step metadata', () => {
     const stepDef: StepDefinition = stepUnderTest.getDefinition();
     expect(stepDef.getStepId()).to.equal('CreateProgramCostStep');
-    expect(stepDef.getName()).to.equal('Create Cost for Marketo Program');
+    expect(stepDef.getName()).to.equal('Create cost for Marketo program');
     expect(stepDef.getExpression()).to.equal('create cost for marketo program');
     expect(stepDef.getType()).to.equal(StepDefinition.Type.ACTION);
   });

--- a/test/steps/programs/program-create.ts
+++ b/test/steps/programs/program-create.ts
@@ -26,7 +26,7 @@ describe('CreateProgramStep', () => {
   it('should return expected step metadata', () => {
     const stepDef: StepDefinition = stepUnderTest.getDefinition();
     expect(stepDef.getStepId()).to.equal('CreateProgramStep');
-    expect(stepDef.getName()).to.equal('Create a Marketo Program');
+    expect(stepDef.getName()).to.equal('Create a Marketo program');
     expect(stepDef.getExpression()).to.equal('create a marketo program');
     expect(stepDef.getType()).to.equal(StepDefinition.Type.ACTION);
   });

--- a/test/steps/programs/program-delete.ts
+++ b/test/steps/programs/program-delete.ts
@@ -26,7 +26,7 @@ describe('DeleteProgramStep', () => {
   it('should return expected step metadata', () => {
     const stepDef: StepDefinition = stepUnderTest.getDefinition();
     expect(stepDef.getStepId()).to.equal('DeleteProgramStep');
-    expect(stepDef.getName()).to.equal('Delete a Marketo Program');
+    expect(stepDef.getName()).to.equal('Delete a Marketo program');
     expect(stepDef.getExpression()).to.equal('delete the (?<name>.+) marketo program');
     expect(stepDef.getType()).to.equal(StepDefinition.Type.ACTION);
   });

--- a/test/steps/programs/program-field-equals.ts
+++ b/test/steps/programs/program-field-equals.ts
@@ -25,7 +25,7 @@ describe('ProgramFieldEqualsStep', () => {
   it('should return expected step metadata', () => {
     const stepDef: StepDefinition = stepUnderTest.getDefinition();
     expect(stepDef.getStepId()).to.equal('ProgramFieldEqualsStep');
-    expect(stepDef.getName()).to.equal('Check a field on a Marketo Program');
+    expect(stepDef.getName()).to.equal('Check a field on a Marketo program');
     expect(stepDef.getExpression()).to.equal('the (?<field>[a-zA-Z0-9_-]+) field on marketo program (?<name>.+) should (?<operator>be set|not be set|be less than|be greater than|be one of|be|contain|not be one of|not be|not contain|match|not match) ?(?<expectation>.+)?');
     expect(stepDef.getType()).to.equal(StepDefinition.Type.VALIDATION);
   });

--- a/test/steps/programs/program-update.ts
+++ b/test/steps/programs/program-update.ts
@@ -26,7 +26,7 @@ describe('UpdateProgramStep', () => {
   it('should return expected step metadata', () => {
     const stepDef: StepDefinition = stepUnderTest.getDefinition();
     expect(stepDef.getStepId()).to.equal('UpdateProgramStep');
-    expect(stepDef.getName()).to.equal('Update a Marketo Program');
+    expect(stepDef.getName()).to.equal('Update a Marketo program');
     expect(stepDef.getExpression()).to.equal('update a marketo program');
     expect(stepDef.getType()).to.equal(StepDefinition.Type.ACTION);
   });

--- a/test/steps/send-sample-email.ts
+++ b/test/steps/send-sample-email.ts
@@ -26,7 +26,7 @@ describe('SendSampleEmailStep', () => {
   it('should return expected step metadata', () => {
     const stepDef: StepDefinition = stepUnderTest.getDefinition();
     expect(stepDef.getStepId()).to.equal('SendSampleEmailStep');
-    expect(stepDef.getName()).to.equal('Send Sample Email');
+    expect(stepDef.getName()).to.equal('Send sample email');
     expect(stepDef.getExpression()).to.equal('send a sample email to (?<emailAddress>.+\@.+\..+)');
     expect(stepDef.getType()).to.equal(StepDefinition.Type.ACTION);
   });

--- a/test/steps/smart-campaign-add-lead.ts
+++ b/test/steps/smart-campaign-add-lead.ts
@@ -29,7 +29,7 @@ describe('AddLeadToSmartCampaignStep', () => {
     it('should return expected step metadata', () => {
       const stepDef: StepDefinition = stepUnderTest.getDefinition();
       expect(stepDef.getStepId()).to.equal('AddLeadToSmartCampaignStep');
-      expect(stepDef.getName()).to.equal('Add Marketo Lead to Smart Campaign');
+      expect(stepDef.getName()).to.equal('Add Marketo lead to smart campaign');
       expect(stepDef.getExpression()).to.equal('add the (?<email>.+) marketo lead to smart campaign (?<campaign>.+)');
       expect(stepDef.getType()).to.equal(StepDefinition.Type.ACTION);
     });

--- a/test/steps/static-lists/static-list-add-lead.ts
+++ b/test/steps/static-lists/static-list-add-lead.ts
@@ -26,7 +26,7 @@ describe('AddLeadToStaticListStep', () => {
   it('should return expected step metadata', () => {
     const stepDef: StepDefinition = stepUnderTest.getDefinition();
     expect(stepDef.getStepId()).to.equal('AddLeadToStaticListStep');
-    expect(stepDef.getName()).to.equal('Add Marketo Leads to Static List');
+    expect(stepDef.getName()).to.equal('Add Marketo leads to static list');
     expect(stepDef.getExpression()).to.equal('add marketo leads to static list (?<staticListName>.+)');
     expect(stepDef.getType()).to.equal(StepDefinition.Type.ACTION);
   });

--- a/test/steps/static-lists/static-list-member-count.ts
+++ b/test/steps/static-lists/static-list-member-count.ts
@@ -26,7 +26,7 @@ describe('StaticListMemberCountStep', () => {
   it('should return expected step metadata', () => {
     const stepDef: StepDefinition = stepUnderTest.getDefinition();
     expect(stepDef.getStepId()).to.equal('StaticListMemberCountStep');
-    expect(stepDef.getName()).to.equal('Count a Marketo Static List');
+    expect(stepDef.getName()).to.equal('Count a Marketo static list');
     expect(stepDef.getExpression()).to.equal('check the number of members from marketo static list (?<staticListName>.+)');
     expect(stepDef.getType()).to.equal(StepDefinition.Type.VALIDATION);
   });

--- a/test/steps/static-lists/static-list-remove-lead.ts
+++ b/test/steps/static-lists/static-list-remove-lead.ts
@@ -26,8 +26,8 @@ describe('RemoveLeadToStaticListStep', () => {
   it('should return expected step metadata', () => {
     const stepDef: StepDefinition = stepUnderTest.getDefinition();
     expect(stepDef.getStepId()).to.equal('RemoveLeadToStaticListStep');
-    expect(stepDef.getName()).to.equal('Remove Marketo Leads to Static List');
-    expect(stepDef.getExpression()).to.equal('remove marketo leads to static list (?<staticListName>.+)');
+    expect(stepDef.getName()).to.equal('Remove Marketo leads from static list');
+    expect(stepDef.getExpression()).to.equal('remove marketo leads from static list (?<staticListName>.+)');
     expect(stepDef.getType()).to.equal(StepDefinition.Type.ACTION);
   });
 


### PR DESCRIPTION
- Added two new fields to each step: actionList and targetObject.
- Changed step names to lowercase except for first word and any proper nouns like Marketo.
- Updated crank cog utilities
- Updated tests to accept new step names