### PR TITLE
Bulk step fixes

### DIFF
--- a/src/steps/lead-field-equals.ts
+++ b/src/steps/lead-field-equals.ts
@@ -145,7 +145,7 @@ export class LeadFieldEqualsStep extends BaseStep implements StepInterface {
           }
 
           leadArray.forEach((emailOrId: string, index: number) => {
-            indexMap[lookupField] = expectedValue[index];
+            indexMap[emailOrId] = expectedValue[index];
           });
         }
 

--- a/src/steps/program-members/program-member-add-or-remove.ts
+++ b/src/steps/program-members/program-member-add-or-remove.ts
@@ -85,13 +85,13 @@ export class AddOrRemoveProgramMemberStep extends BaseStep implements StepInterf
           const bulkFindLeadResponse = await this.client.bulkFindLeadsByEmail(stepData.multiple_email, null, partitionId);
           await bulkFindLeadResponse.forEach(async (batch) => {
             if (!batch.success) {
-              return this.error('There was an error finding some lead IDs in partition %d: %s', [partitionId, batch.message]);
+              return this.error('There was an error finding some lead IDs: %s', [batch.message]);
             }
             count += batch.result.length;
           });
 
           if (count !== stepData.multiple_email.length) {
-            return this.error('Could not find all leads provided in partition %d', [partitionId]);
+            return this.error('Could not find all leads provided');
           }
 
         } else {
@@ -103,7 +103,7 @@ export class AddOrRemoveProgramMemberStep extends BaseStep implements StepInterf
           const bulkFindLeadResponse = await this.client.bulkFindLeadsById(stepData.multiple_email, null, partitionId);
           await bulkFindLeadResponse.forEach(async (batch) => {
             if (!batch.success) {
-              return this.error('There was an error finding some leads in partition %d: %s', [partitionId, batch.message]);
+              return this.error('There was an error finding some leads: %s', [batch.message]);
             }
 
             await batch.result.forEach((lead) => {
@@ -115,7 +115,7 @@ export class AddOrRemoveProgramMemberStep extends BaseStep implements StepInterf
           });
 
           if (count !== stepData.multiple_email.length) {
-            return this.error('Could not find all leads provided in partition %d', [partitionId]);
+            return this.error('Could not find all leads provided');
           }
 
         }
@@ -124,19 +124,19 @@ export class AddOrRemoveProgramMemberStep extends BaseStep implements StepInterf
         if (emailRegex.test(stepData.email)) {
           const response = await this.client.findLeadByEmail(stepData.email, null, partitionId);
           if (!response.success) {
-            return this.error('There was an error finding lead %d in partition %d', [stepData.email, partitionId]);
+            return this.error('There was an error finding lead %s', [stepData.email.toString()]);
           }
           leadEmailArray.push(stepData.email);
         } else {
           try {
             const response = await this.client.findLeadByField('id', stepData.email, null, partitionId);
-            const email = response.result[0].email;
-            if (!response.success || !email) {
-              return this.error('There was an error finding lead %d in partition %d', [stepData.email, partitionId]);
+            if (!response.success || !response.result.length || !response.result[0].email) {
+              console.log('response:', response)
+              return this.error('There was an error finding lead %s', [stepData.email.toString()]);
             }
-            leadEmailArray.push(email);
+            leadEmailArray.push(response.result[0].email);
           } catch (e) {
-            return this.error('There was an error finding lead %d in partition %d', [stepData.email, partitionId]);
+            return this.error('There was an error finding lead %s', [stepData.email.toString()]);
           }
         }
       }

--- a/src/steps/program-members/program-member-add-or-remove.ts
+++ b/src/steps/program-members/program-member-add-or-remove.ts
@@ -131,7 +131,6 @@ export class AddOrRemoveProgramMemberStep extends BaseStep implements StepInterf
           try {
             const response = await this.client.findLeadByField('id', stepData.email, null, partitionId);
             if (!response.success || !response.result.length || !response.result[0].email) {
-              console.log('response:', response)
               return this.error('There was an error finding lead %s', [stepData.email.toString()]);
             }
             leadEmailArray.push(response.result[0].email);

--- a/test/steps/lead-field-equals.ts
+++ b/test/steps/lead-field-equals.ts
@@ -577,6 +577,38 @@ describe('LeadFieldEqualsStep', () => {
       expect(response.toObject().messageFormat).to.contain('Successfully checked %d leads');
     });
     
+    it('should respond with a pass if the field on the lead matches the expectation by ID', async () => {
+      clientWrapperStub.bulkFindLeadsById = sinon.stub();
+      protoStep.setData(Struct.fromJavaScript({
+        expectation: 'Atoma',
+        email: 'dummyEmail',
+        multiple_email: ['111111', '111112', '111113'],
+        field: 'firstName',
+      }));
+  
+      // Have the client respond with a valid, but mismatched lead.
+      clientWrapperStub.bulkFindLeadsById.returns(Promise.resolve([{
+        success: true,
+        result: [{
+          firstName: 'Atoma',
+          id: '111111',
+          email: 'expected1@example.com',
+        }, {
+          firstName: 'Atoma',
+          id: '111112',
+          email: 'expected2@example.com',
+        }, {
+          firstName: 'Atoma',
+          id: '111113',
+          email: 'expected3@example.com',
+        }],
+      }]));
+  
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+      expect(response.toObject().messageFormat).to.contain('Successfully checked %d leads');
+    });
+    
     it('should respond with a pass if the fields on all leads match dynamic expectations', async () => {
       protoStep.setData(Struct.fromJavaScript({
         expectation: 'Atoma',
@@ -600,6 +632,39 @@ describe('LeadFieldEqualsStep', () => {
         }, {
           firstName: 'expectation3',
           id: 3,
+          email: 'expected3@example.com',
+        }],
+      }]));
+  
+      const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+      expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+      expect(response.toObject().messageFormat).to.contain('Successfully checked %d leads');
+    });
+    
+    it('should respond with a pass if the fields on all leads match dynamic expectations by ID', async () => {
+      clientWrapperStub.bulkFindLeadsById = sinon.stub();
+      protoStep.setData(Struct.fromJavaScript({
+        expectation: 'Atoma',
+        email: 'dummyEmail',
+        multiple_email: ['111111', '111112', '111113'],
+        multiple_expectation: ['expectation1', 'expectation2', 'expectation3'],
+        field: 'firstName',
+      }));
+  
+      // Have the client respond with a valid, but mismatched lead.
+      clientWrapperStub.bulkFindLeadsById.returns(Promise.resolve([{
+        success: true,
+        result: [{
+          firstName: 'expectation1',
+          id: '111111',
+          email: 'expected1@example.com',
+        }, {
+          firstName: 'expectation2',
+          id: '111112',
+          email: 'expected2@example.com',
+        }, {
+          firstName: 'expectation3',
+          id: '111113',
           email: 'expected3@example.com',
         }],
       }]));


### PR DESCRIPTION
- LeadFieldEquals step: adjusted bulk logic to handle IDs as well as emails (bug 6278)
- AddOrRemoveProgramMember step: fixed issue where step message wasn't being sent back properly (bug 6291)
- Added new tests for leadFieldEquals step