### PR TITLE
Changed dockerhub repo and adjusted max field length for api calls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,12 +2,12 @@ version: 2.1
 executors:
   docker-publisher:
     environment:
-      IMAGE_NAME: automatoninc/marketo
+      IMAGE_NAME: stackmoxie/marketo
     docker:
       - image: cimg/base:stable
   docker-user:
     environment:
-      IMAGE_NAME: automatoninc/marketo
+      IMAGE_NAME: stackmoxie/marketo
     machine:
       image: ubuntu-2004:202201-02
 
@@ -94,7 +94,7 @@ jobs:
             curl -s https://get.crank.run/install.sh | sh
             docker tag $IMAGE_NAME:latest $IMAGE_NAME:local-test
             crank cog:install $IMAGE_NAME:local-test
-            crank cog:install automatoninc/web:0.3.1
+            crank cog:install stackmoxie/web:dev-v1542
       # - run:
       #     name: Run all test scenarios
       #     command: crank run ./test/scenarios
@@ -111,7 +111,7 @@ jobs:
       - run:
           name: Publish Docker Image to Docker Hub
           command: |
-            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_SM_USERNAME" --password-stdin
             IMAGE_TAG="dev-v${CIRCLE_BUILD_NUM}"
             docker tag $IMAGE_NAME:latest $IMAGE_NAME:$IMAGE_TAG
             docker push $IMAGE_NAME:$IMAGE_TAG
@@ -128,7 +128,7 @@ jobs:
       - run:
           name: Publish Docker Image to Docker Hub
           command: |
-            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_SM_USERNAME" --password-stdin
             IMAGE_TAG=${CIRCLE_TAG/v/''}
             docker tag $IMAGE_NAME:latest $IMAGE_NAME:$IMAGE_TAG
             docker push $IMAGE_NAME:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,5 @@ COPY --from=build /usr/local/bin/dumb-init /usr/local/bin/dumb-init
 COPY --from=build /app .
 COPY . .
 EXPOSE 28866
-LABEL com.automatoninc.cog-for="Marketo"
+LABEL com.stackmoxie.cog-for="Marketo"
 ENTRYPOINT ["/usr/local/bin/dumb-init", "--", "node", "build/core/grpc-server.js"]

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ then run the following.  You'll be prompted to enter your Marketo credentials
 once the Cog is successfully installed.
 
 ```shell-session
-$ crank cog:install automatoninc/marketo
+$ crank cog:install stackmoxie/marketo
 ```
 
 Note: You can always re-authenticate later.
@@ -36,7 +36,7 @@ You will be asked for the following authentication details on installation. To a
 
 ```shell-session
 # Re-authenticate by running this
-$ crank cog:auth automatoninc/marketo
+$ crank cog:auth stackmoxie/marketo
 ```
 <!-- authenticationDetailsEnd -->
 
@@ -67,12 +67,12 @@ as appropriate.
 4. Run `npm start` to validate the cog works locally (`ctrl+c` to kill it)
 5. Run `crank cog:install --source=local --local-start-command="npm start"` to
    register your local instance of this cog. You may need to append a `--force`
-   flag or run `crank cog:uninstall automatoninc/marketo` if you've already
+   flag or run `crank cog:uninstall stackmoxie/marketo` if you've already
    installed the distributed version of this cog.
 
 ### Adding/Modifying Steps
 Modify code in `src/steps` and validate your changes by running
-`crank cog:step automatoninc/marketo` and selecting your step.
+`crank cog:step stackmoxie/marketo` and selecting your step.
 
 To add new steps, create new step classes in `src/steps`. Use existing steps as
 a starting point for your new step(s). Note that you will need to run
@@ -93,10 +93,10 @@ Modify the ClientWrapper class at `src/client/client-wrapper.ts`.
 
 Note that you will need to run `crank registry:rebuild` in order for any
 changes to authentication fields to be reflected. Afterward, you can
-re-authenticate this cog by running `crank cog:auth automatoninc/marketo`
+re-authenticate this cog by running `crank cog:auth stackmoxie/marketo`
 
 ### Tests and Housekeeping
 Tests can be found in the `test` directory and run like this: `npm test`.
 Ensure your code meets standards by running `npm run lint`.
 
-[what-is-crank]: https://crank.run?utm_medium=readme&utm_source=automatoninc%2Fmarketo
+[what-is-crank]: https://crank.run?utm_medium=readme&utm_source=stackmoxie%2Fmarketo

--- a/package.json
+++ b/package.json
@@ -4,19 +4,19 @@
   "description": "Marketo Cog for use with Crank",
   "license": "MIT",
   "cog": {
-    "name": "automatoninc/marketo",
+    "name": "stackmoxie/marketo",
     "label": "Marketo",
     "homepage": "https://github.com/run-crank/cog-marketo",
     "authHelpUrl": "https://docs.marketo.com/display/public/DOCS/Create+a+Custom+Service+for+Use+with+ReST+API"
   },
   "scripts": {
-    "build-docker": "docker build -t automatoninc/marketo:$npm_package_version -t automatoninc/marketo:latest .",
+    "build-docker": "docker build -t stackmoxie/marketo:$npm_package_version -t stackmoxie/marketo:latest .",
     "build-proto": "bash scripts/build-proto.sh",
     "build-ts": "tsc",
     "lint": "tslint -c tslint.json -p tsconfig.json",
     "start": "check-engine package.json && node -r ts-node/register src/core/grpc-server.ts",
     "test": "nyc mocha -r ts-node/register test/*.ts test/**/*.ts test/**/**/*.ts --exit",
-    "version": "crank cog:readme automatoninc/marketo && git add README.md"
+    "version": "crank cog:readme stackmoxie/marketo && git add README.md"
   },
   "nyc": {
     "extension": [

--- a/src/client/mixins/lead-aware.ts
+++ b/src/client/mixins/lead-aware.ts
@@ -277,13 +277,13 @@ export class LeadAwareMixin {
       'leadPartitionId',
     ].filter(f => !!f);
 
-    if (fieldList.join(',').length > 7168 && fieldList.length >= 1000) {
+    if (fieldList.join(',').length > 7000 && fieldList.length >= 1000) {
       // If the length of the get request would be over 7KB, then the request
       // would fail. And if the amount of fields is over 1000, it is likely
       // not worth it to cache with the if statement below.
       // Instead, we will only request the needed fields.
       response = await this.client.lead.find(field, [value], { fields: mustHaveFields });
-    } else if (fieldList.join(',').length > 7168) {
+    } else if (fieldList.join(',').length > 7000) {
       // If the length of the get request would be over 7KB, then the request
       // would fail. Instead, we will split the request every 200 fields, and
       // combine the results.
@@ -320,9 +320,9 @@ export class LeadAwareMixin {
     ].filter(f => !!f);
     let response: any = {};
 
-    if (fieldList.join(',').length > 7168 && fieldList.length >= 1000) {
+    if (fieldList.join(',').length > 7000 && fieldList.length >= 1000) {
       response = await this.client.lead.find('email', [email], { fields: mustHaveFields });
-    } else if (fieldList.join(',').length > 7168) {
+    } else if (fieldList.join(',').length > 7000) {
       response = await this.marketoRequestHelperFuntion(fieldList, 'email', email);
     } else {
       response = await this.client.lead.find('email', [email], { fields: fieldList });

--- a/test/core/cog.ts
+++ b/test/core/cog.ts
@@ -26,7 +26,7 @@ describe('Cog:GetManifest', () => {
   it('should return expected cog metadata', (done) => {
     const version: string = JSON.parse(fs.readFileSync('package.json').toString('utf8')).version;
     cogUnderTest.getManifest(null, (err, manifest: CogManifest) => {
-      expect(manifest.getName()).to.equal('automatoninc/marketo');
+      expect(manifest.getName()).to.equal('stackmoxie/marketo');
       expect(manifest.getLabel()).to.equal('Marketo');
       expect(manifest.getVersion()).to.equal(version);
       done();


### PR DESCRIPTION
- In findLeadByEmail and findLeadByField methods: Changed max length of characters in the fieldList to be 7000 before we break the fields into chunks. When the length is larger than 7k then we will break the api calls into chunks of 200 fields max. This will prevent Marketo from returning and error with status 500 "Unknown Marketo error."
- Updated dockerhub repo to stackmoxie/marketo