### PR TITLE
Handle case where findLeadByField method returns an empty object

### DIFF
--- a/src/steps/check-lead-activity-by-id.ts
+++ b/src/steps/check-lead-activity-by-id.ts
@@ -81,8 +81,8 @@ export class CheckLeadActivityByIdStep extends BaseStep implements StepInterface
 
       const lead = (await this.client.findLeadByField('id', id, null, partitionId)).result[0];
 
-      /* Error when lead is not found */
-      if (!lead) {
+      /* Error when lead is not found OR if lead is an empty object */
+      if (!lead || !Object.keys(lead).length) {
         return this.fail('Lead %s was not found%s', [
           id,
           partitionId ? ` in partition ${partitionId}` : '',

--- a/src/steps/check-lead-activity.ts
+++ b/src/steps/check-lead-activity.ts
@@ -354,8 +354,8 @@ export class CheckLeadActivityStep extends BaseStep implements StepInterface {
 
         const lead = (await this.client.findLeadByField(lookupField, reference, null, partitionId)).result[0];
 
-        /* Error when lead is not found */
-        if (!lead) {
+        /* Error when lead is not found OR if lead is an empty object */
+        if (!lead || !Object.keys(lead).length) {
           return this.fail('Lead %s was not found%s', [
             reference,
             partitionId ? ` in partition ${partitionId}` : '',
@@ -433,6 +433,7 @@ export class CheckLeadActivityStep extends BaseStep implements StepInterface {
       }
 
     } catch (e) {
+      console.log(e);
       return this.error('There was an error checking activities for Marketo Lead: %s', [
         e.toString(),
       ]);

--- a/src/steps/smart-campaign-add-lead.ts
+++ b/src/steps/smart-campaign-add-lead.ts
@@ -233,7 +233,7 @@ export class AddLeadToSmartCampaignStep extends BaseStep implements StepInterfac
 
         const findLeadResponse: any = await this.client.findLeadByField(lookupField, reference, null, partitionId);
 
-        if (!findLeadResponse.result[0]) {
+        if (!findLeadResponse.result[0] || !Object.keys(findLeadResponse.result[0]).length) {
           return this.fail(
             'Couldn\'t find a lead associated with %s%s', [
               findLeadResponse,

--- a/test/steps/check-lead-activity-by-id.ts
+++ b/test/steps/check-lead-activity-by-id.ts
@@ -99,7 +99,7 @@ describe('CheckLeadActivityByIdStep', () => {
         }));
 
         clientWrapperStub.findLeadByField.returns(Promise.resolve({
-          result: [{}],
+          result: [{ id: 10001 }],
         }));
 
         clientWrapperStub.getActivityTypes.returns(Promise.resolve({


### PR DESCRIPTION
- Fixed an error where the findLeadByField method was successfully returning a lead object, but the object is empty. The steps were returning a generic ERROR state, but now they will return a FAILED state with a message that we could not find the lead.
- Fixed the "Activity Type not found" test