### PR TITLE
Fix a bug where an error was returned when we could not find program.…

### DIFF
--- a/src/steps/programs/program-field-equals.ts
+++ b/src/steps/programs/program-field-equals.ts
@@ -96,9 +96,9 @@ export class ProgramFieldEqualsStep extends BaseStep implements StepInterface {
           : this.fail(result.message, [], [record, orderedRecord]);
 
       } else {
-        const record = this.createRecord(data.result[0]);
-        const orderedRecord = this.createOrderedRecord(data.result[0], stepData['__stepOrder']);
         if (data.result && data.result[0] && !data.result[0][field]) {
+          const record = this.createRecord(data.result[0]);
+          const orderedRecord = this.createOrderedRecord(data.result[0], stepData['__stepOrder']);
           return this.fail(
             'Found the %s program, but there was no %s field.',
             [name, field],


### PR DESCRIPTION
Fix a bug where an Error was returned when we could not find program with a given name. Now it will return a fail with a more descriptive message: "Couldn't find program associated with {{name}}"