### PR TITLE
Rhart/update most recent match

### DIFF
--- a/src/steps/lead-update.ts
+++ b/src/steps/lead-update.ts
@@ -6,7 +6,7 @@ import { Step, FieldDefinition, StepDefinition, RecordDefinition, StepRecord } f
 export class UpdateLeadStep extends BaseStep implements StepInterface {
 
   protected stepName: string = 'Update a Marketo lead';
-  protected stepExpression: string = 'update a marketo lead';
+  protected stepExpression: string = 'update an existing marketo lead';
   protected stepType: StepDefinition.Type = StepDefinition.Type.ACTION;
   protected actionList: string[] = ['update'];
   protected targetObject: string = 'Lead';

--- a/test/steps/lead-update.ts
+++ b/test/steps/lead-update.ts
@@ -28,7 +28,7 @@ describe('UpdateLeadStep', () => {
     const stepDef: StepDefinition = stepUnderTest.getDefinition();
     expect(stepDef.getStepId()).to.equal('UpdateLeadStep');
     expect(stepDef.getName()).to.equal('Update a Marketo lead');
-    expect(stepDef.getExpression()).to.equal('update a marketo lead');
+    expect(stepDef.getExpression()).to.equal('update an existing marketo lead');
     expect(stepDef.getType()).to.equal(StepDefinition.Type.ACTION);
   });
 


### PR DESCRIPTION
- Added updateMostRecentMatch optional boolean field to lead-create-or-update and bulk-lead-create-or-update steps (hidden from frontend, defaults to false)
- Implemented duplicate lead resolution logic: When updateMostRecentMatch is true and Marketo returns "Multiple lead match lookup criteria" error:
  - Calls findLeadByEmail to retrieve all matching leads
  - Sorts leads by updatedAt (falls back to createdAt) to identify the most recent lead
  - Updates the most recent lead by ID using updateLead with lookupField: 'id'
  - Returns success with details about which lead was updated
- Updated unit tests for both lead-create-or-update.ts and bulk-lead-create-or-update.ts to cover new scenarios:
  - Success case when updateMostRecentMatch is true with multiple matches
  - Failure case when updateMostRecentMatch is false (preserves existing behavior)
  - Edge cases for resolution failures
- Fixed step expression conflict: Changed lead-update.ts step expression from "update a marketo lead" to "update an existing marketo lead" to prevent incorrect step matching