### PR TITLE
Add check-bulk-api-usage step for Marketo bulk export monitoring

### DIFF
--- a/src/client/mixins/stats-aware.ts
+++ b/src/client/mixins/stats-aware.ts
@@ -18,6 +18,43 @@ export class StatsAwareMixin {
     return await this.client._connection.get('/v1/stats/usage/last7days.json');
   }
 
+  public async getBulkExportLeadJobs() {
+    if (this.delayInSeconds > 0) {
+      await this.delay(this.delayInSeconds);
+    }
+    // Get the base endpoint URL (without /rest) and construct full bulk API URL
+    const baseEndpoint = this.client._connection._options.endpoint.replace('/rest', '');
+    const fullUrl = `${baseEndpoint}/bulk/v1/leads/export.json`;
+    const options = {
+      data: { _method: 'GET' },
+    };
+    return await this.client._connection.get(fullUrl, options);
+  }
+
+  public async getBulkExportActivityJobs() {
+    if (this.delayInSeconds > 0) {
+      await this.delay(this.delayInSeconds);
+    }
+    const baseEndpoint = this.client._connection._options.endpoint.replace('/rest', '');
+    const fullUrl = `${baseEndpoint}/bulk/v1/activities/export.json`;
+    const options = {
+      data: { _method: 'GET' },
+    };
+    return await this.client._connection.get(fullUrl, options);
+  }
+
+  public async getBulkExportProgramMemberJobs() {
+    if (this.delayInSeconds > 0) {
+      await this.delay(this.delayInSeconds);
+    }
+    const baseEndpoint = this.client._connection._options.endpoint.replace('/rest', '');
+    const fullUrl = `${baseEndpoint}/bulk/v1/program/members/export.json`;
+    const options = {
+      data: { _method: 'GET' },
+    };
+    return await this.client._connection.get(fullUrl, options);
+  }
+
   public async delay(seconds: number) {
     return new Promise(resolve => setTimeout(resolve, seconds * 1000));
   }

--- a/src/steps/check-bulk-api-usage.ts
+++ b/src/steps/check-bulk-api-usage.ts
@@ -1,0 +1,95 @@
+/*tslint:disable:no-else-after-return*/
+
+import { BaseStep, Field, StepInterface, ExpectedRecord } from '../core/base-step';
+import { Step, FieldDefinition, StepDefinition, RecordDefinition } from '../proto/cog_pb';
+
+export class CheckBulkApiUsageStep extends BaseStep implements StepInterface {
+
+  protected stepName: string = 'Check daily Marketo Bulk API usage';
+  protected stepExpression: string = 'there should be less than 90% usage of your daily bulk API limit';
+  protected stepType: StepDefinition.Type = StepDefinition.Type.VALIDATION;
+  protected actionList: string[] = ['check'];
+  protected targetObject: string = 'Bulk API Usage';
+  protected expectedFields: Field[] = [{
+    field: 'exportLimit',
+    type: FieldDefinition.Type.NUMERIC,
+    optionality: FieldDefinition.Optionality.OPTIONAL,
+    description: 'Your daily bulk export limit in MB (default: 500)',
+  }];
+  protected expectedRecords: ExpectedRecord[] = [{
+    id: 'bulkExports',
+    type: RecordDefinition.Type.KEYVALUE,
+    fields: [{
+      field: 'bulkApiUsage',
+      type: FieldDefinition.Type.NUMERIC,
+      description: 'Daily Bulk API Usage in MB',
+    }],
+    dynamicFields: false,
+  }];
+
+  async executeStep(step: Step) {
+    const stepData: any = step.getData().toJavaScript();
+    const exportLimitMB = stepData.exportLimit || 500;
+    const exportLimitBytes = exportLimitMB * 1024 * 1024;
+
+    try {
+      // Get all export jobs from the different bulk API endpoints
+      const leadJobsResponse = await this.client.getBulkExportLeadJobs();
+      const activityJobsResponse = await this.client.getBulkExportActivityJobs();
+      const programMemberJobsResponse = await this.client.getBulkExportProgramMemberJobs();
+
+      // Calculate today's total usage by summing fileSize from all completed jobs created today
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+
+      let totalBytesToday = 0;
+      let jobCount = 0;
+
+      // Helper function to process jobs from each endpoint
+      const processJobs = (jobs: any[]) => {
+        if (!jobs || !Array.isArray(jobs)) {
+          return;
+        }
+
+        jobs.forEach((job) => {
+          // Only count jobs created today and that have completed
+          const createdAt = new Date(job.createdAt);
+          createdAt.setHours(0, 0, 0, 0);
+
+          if (createdAt.getTime() === today.getTime() && job.status === 'Completed' && job.fileSize) {
+            totalBytesToday += job.fileSize;
+            jobCount += 1;
+          }
+        });
+      };
+
+      // Process jobs from all endpoints
+      if (leadJobsResponse.result) {
+        processJobs(leadJobsResponse.result);
+      }
+      if (activityJobsResponse.result) {
+        processJobs(activityJobsResponse.result);
+      }
+      if (programMemberJobsResponse.result) {
+        processJobs(programMemberJobsResponse.result);
+      }
+
+      // Convert to MB for display
+      const totalMBUsed = (totalBytesToday / (1024 * 1024)).toFixed(2);
+      const percentUsage = ((totalBytesToday / exportLimitBytes) * 100).toFixed(2);
+
+      if (totalBytesToday < (0.9 * exportLimitBytes)) {
+        return this.pass('You have used %s MB of your %d MB daily bulk export limit, which is %s%% of your quota. This is based on %d completed export job(s) today.',
+                         [totalMBUsed, exportLimitMB, percentUsage, jobCount],
+                         [this.keyValue('bulkExports', 'Checked Bulk API Usage', { bulkApiUsage: parseFloat(totalMBUsed) })]);
+      }
+      return this.fail('You have used %s MB of your %d MB daily bulk export limit, which is %s%% of your quota. This is based on %d completed export job(s) today. You are approaching or have exceeded your daily limit.',
+                       [totalMBUsed, exportLimitMB, percentUsage, jobCount],
+                       [this.keyValue('bulkExports', 'Checked Bulk API Usage', { bulkApiUsage: parseFloat(totalMBUsed) })]);
+    } catch (e) {
+      return this.error('There was a problem checking the Bulk API Usage: %s', [e.toString()]);
+    }
+  }
+}
+
+export { CheckBulkApiUsageStep as Step };

--- a/src/steps/lead-update.ts
+++ b/src/steps/lead-update.ts
@@ -6,7 +6,7 @@ import { Step, FieldDefinition, StepDefinition, RecordDefinition, StepRecord } f
 export class UpdateLeadStep extends BaseStep implements StepInterface {
 
   protected stepName: string = 'Update a Marketo lead';
-  protected stepExpression: string = 'update a marketo lead';
+  protected stepExpression: string = 'update an existing marketo lead';
   protected stepType: StepDefinition.Type = StepDefinition.Type.ACTION;
   protected actionList: string[] = ['update'];
   protected targetObject: string = 'Lead';

--- a/test/steps/check-bulk-api-usage.ts
+++ b/test/steps/check-bulk-api-usage.ts
@@ -1,0 +1,273 @@
+import { Struct } from 'google-protobuf/google/protobuf/struct_pb';
+import * as chai from 'chai';
+import { default as sinon } from 'ts-sinon';
+import * as sinonChai from 'sinon-chai';
+import 'mocha';
+
+import { Step as ProtoStep, StepDefinition, RunStepResponse } from '../../src/proto/cog_pb';
+import { Step } from '../../src/steps/check-bulk-api-usage';
+
+chai.use(sinonChai);
+
+describe('CheckBulkApiUsageStep', () => {
+  const expect = chai.expect;
+  let protoStep: ProtoStep;
+  let stepUnderTest: Step;
+  let clientWrapperStub: any;
+
+  beforeEach(() => {
+    protoStep = new ProtoStep();
+    clientWrapperStub = sinon.stub();
+    clientWrapperStub.getBulkExportLeadJobs = sinon.stub();
+    clientWrapperStub.getBulkExportActivityJobs = sinon.stub();
+    clientWrapperStub.getBulkExportProgramMemberJobs = sinon.stub();
+    stepUnderTest = new Step(clientWrapperStub);
+  });
+
+  it('should return expected step metadata', () => {
+    const stepDef: StepDefinition = stepUnderTest.getDefinition();
+    expect(stepDef.getStepId()).to.equal('CheckBulkApiUsageStep');
+    expect(stepDef.getName()).to.equal('Check daily Marketo Bulk API usage');
+    expect(stepDef.getExpression()).to.equal('there should be less than 90% usage of your daily bulk API limit');
+    expect(stepDef.getType()).to.equal(StepDefinition.Type.VALIDATION);
+  });
+
+  it('should respond with success if bulk API usage is less than 90% of the daily limit', async () => {
+    const expectedLimit: number = 500; // 500MB default
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    
+    protoStep.setData(Struct.fromJavaScript({
+      exportLimit: expectedLimit,
+    }));
+    
+    // Mock lead export jobs - 100MB used today
+    clientWrapperStub.getBulkExportLeadJobs.returns(Promise.resolve({
+      success: true,
+      result: [
+        {
+          createdAt: today.toISOString(),
+          status: 'Completed',
+          fileSize: 100 * 1024 * 1024, // 100MB
+        },
+      ],
+    }));
+    
+    // Mock activity export jobs - 50MB used today
+    clientWrapperStub.getBulkExportActivityJobs.returns(Promise.resolve({
+      success: true,
+      result: [
+        {
+          createdAt: today.toISOString(),
+          status: 'Completed',
+          fileSize: 50 * 1024 * 1024, // 50MB
+        },
+      ],
+    }));
+    
+    // Mock program member export jobs - empty
+    clientWrapperStub.getBulkExportProgramMemberJobs.returns(Promise.resolve({
+      success: true,
+      result: [],
+    }));
+    
+    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+  });
+
+  it('should respond with a failure if bulk API usage is more than 90% of the daily limit', async () => {
+    const expectedLimit: number = 500;
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    
+    protoStep.setData(Struct.fromJavaScript({
+      exportLimit: expectedLimit,
+    }));
+    
+    // Mock lead export jobs - 400MB used today
+    clientWrapperStub.getBulkExportLeadJobs.returns(Promise.resolve({
+      success: true,
+      result: [
+        {
+          createdAt: today.toISOString(),
+          status: 'Completed',
+          fileSize: 400 * 1024 * 1024, // 400MB
+        },
+      ],
+    }));
+    
+    // Mock activity export jobs - 100MB used today
+    clientWrapperStub.getBulkExportActivityJobs.returns(Promise.resolve({
+      success: true,
+      result: [
+        {
+          createdAt: today.toISOString(),
+          status: 'Completed',
+          fileSize: 100 * 1024 * 1024, // 100MB
+        },
+      ],
+    }));
+    
+    // Mock program member export jobs - empty
+    clientWrapperStub.getBulkExportProgramMemberJobs.returns(Promise.resolve({
+      success: true,
+      result: [],
+    }));
+    
+    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.FAILED);
+  });
+
+  it('should only count jobs from today', async () => {
+    const expectedLimit: number = 500;
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const yesterday = new Date(today);
+    yesterday.setDate(yesterday.getDate() - 1);
+    
+    protoStep.setData(Struct.fromJavaScript({
+      exportLimit: expectedLimit,
+    }));
+    
+    // Mock lead export jobs - one from today (50MB), one from yesterday (400MB)
+    clientWrapperStub.getBulkExportLeadJobs.returns(Promise.resolve({
+      success: true,
+      result: [
+        {
+          createdAt: today.toISOString(),
+          status: 'Completed',
+          fileSize: 50 * 1024 * 1024, // 50MB today
+        },
+        {
+          createdAt: yesterday.toISOString(),
+          status: 'Completed',
+          fileSize: 400 * 1024 * 1024, // 400MB yesterday (should not count)
+        },
+      ],
+    }));
+    
+    clientWrapperStub.getBulkExportActivityJobs.returns(Promise.resolve({
+      success: true,
+      result: [],
+    }));
+    
+    clientWrapperStub.getBulkExportProgramMemberJobs.returns(Promise.resolve({
+      success: true,
+      result: [],
+    }));
+    
+    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+    // Should pass because only 50MB from today counts
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+  });
+
+  it('should only count completed jobs', async () => {
+    const expectedLimit: number = 500;
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    
+    protoStep.setData(Struct.fromJavaScript({
+      exportLimit: expectedLimit,
+    }));
+    
+    // Mock lead export jobs - one completed (50MB), one queued (400MB)
+    clientWrapperStub.getBulkExportLeadJobs.returns(Promise.resolve({
+      success: true,
+      result: [
+        {
+          createdAt: today.toISOString(),
+          status: 'Completed',
+          fileSize: 50 * 1024 * 1024, // 50MB completed
+        },
+        {
+          createdAt: today.toISOString(),
+          status: 'Queued',
+          fileSize: 400 * 1024 * 1024, // 400MB queued (should not count)
+        },
+      ],
+    }));
+    
+    clientWrapperStub.getBulkExportActivityJobs.returns(Promise.resolve({
+      success: true,
+      result: [],
+    }));
+    
+    clientWrapperStub.getBulkExportProgramMemberJobs.returns(Promise.resolve({
+      success: true,
+      result: [],
+    }));
+    
+    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+    // Should pass because only 50MB from completed jobs counts
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+  });
+
+  it('should handle empty results', async () => {
+    const expectedLimit: number = 500;
+    
+    protoStep.setData(Struct.fromJavaScript({
+      exportLimit: expectedLimit,
+    }));
+    
+    clientWrapperStub.getBulkExportLeadJobs.returns(Promise.resolve({
+      success: true,
+      result: [],
+    }));
+    
+    clientWrapperStub.getBulkExportActivityJobs.returns(Promise.resolve({
+      success: true,
+      result: [],
+    }));
+    
+    clientWrapperStub.getBulkExportProgramMemberJobs.returns(Promise.resolve({
+      success: true,
+      result: [],
+    }));
+    
+    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+    // Should pass with 0MB usage
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+  });
+
+  it('should respond with an error if the marketo client throws an error', async () => {
+    clientWrapperStub.getBulkExportLeadJobs.throws('any error');
+    protoStep.setData(Struct.fromJavaScript({
+      exportLimit: 500,
+    }));
+    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
+  });
+
+  it('should use default limit of 500MB when not specified', async () => {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    
+    // Don't set exportLimit, should default to 500MB
+    protoStep.setData(Struct.fromJavaScript({}));
+    
+    clientWrapperStub.getBulkExportLeadJobs.returns(Promise.resolve({
+      success: true,
+      result: [
+        {
+          createdAt: today.toISOString(),
+          status: 'Completed',
+          fileSize: 400 * 1024 * 1024, // 400MB
+        },
+      ],
+    }));
+    
+    clientWrapperStub.getBulkExportActivityJobs.returns(Promise.resolve({
+      success: true,
+      result: [],
+    }));
+    
+    clientWrapperStub.getBulkExportProgramMemberJobs.returns(Promise.resolve({
+      success: true,
+      result: [],
+    }));
+    
+    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+    // Should pass because 400MB < 90% of 500MB (450MB)
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+  });
+});

--- a/test/steps/lead-update.ts
+++ b/test/steps/lead-update.ts
@@ -28,7 +28,7 @@ describe('UpdateLeadStep', () => {
     const stepDef: StepDefinition = stepUnderTest.getDefinition();
     expect(stepDef.getStepId()).to.equal('UpdateLeadStep');
     expect(stepDef.getName()).to.equal('Update a Marketo lead');
-    expect(stepDef.getExpression()).to.equal('update a marketo lead');
+    expect(stepDef.getExpression()).to.equal('update an existing marketo lead');
     expect(stepDef.getType()).to.equal(StepDefinition.Type.ACTION);
   });
 


### PR DESCRIPTION
## Summary
- Adds new \`check-bulk-api-usage\` step to monitor Marketo's daily bulk export API quota
- Monitors the 500MB daily limit (configurable) across leads, activities, and program member exports
- Passes if usage < 90% of daily quota

## Changes
- Added \`getBulkExportLeadJobs()\`, \`getBulkExportActivityJobs()\`, and \`getBulkExportProgramMemberJobs()\` methods to \`StatsAwareMixin\`
- Created \`check-bulk-api-usage.ts\` step with comprehensive logic to sum fileSize from completed jobs created today
- Added full test suite with 8 test cases covering edge cases

## Test Plan
- [x] All existing tests pass
- [x] New tests pass (8/8)
- [x] Linter passes
- [x] Tested live against Marketo instance
- [x] Step correctly identifies jobs and calculates usage"