### PR TITLE
Add previousUsageMB field to accumulate bulk API usage across users

### DIFF
--- a/src/client/caching-client-wrapper.ts
+++ b/src/client/caching-client-wrapper.ts
@@ -267,6 +267,14 @@ class CachingClientWrapper {
     return await this.client.getBulkExportProgramMemberJobs();
   }
 
+  public async getCustomObjectTypes() {
+    return await this.client.getCustomObjectTypes();
+  }
+
+  public async getBulkExportCustomObjectJobs(apiName: string) {
+    return await this.client.getBulkExportCustomObjectJobs(apiName);
+  }
+
   public async createProgram(program) {
     return await this.client.createProgram(program);
   }

--- a/src/client/caching-client-wrapper.ts
+++ b/src/client/caching-client-wrapper.ts
@@ -255,6 +255,18 @@ class CachingClientWrapper {
     return await this.client.getWeeklyApiUsage();
   }
 
+  public async getBulkExportLeadJobs() {
+    return await this.client.getBulkExportLeadJobs();
+  }
+
+  public async getBulkExportActivityJobs() {
+    return await this.client.getBulkExportActivityJobs();
+  }
+
+  public async getBulkExportProgramMemberJobs() {
+    return await this.client.getBulkExportProgramMemberJobs();
+  }
+
   public async createProgram(program) {
     return await this.client.createProgram(program);
   }

--- a/src/client/mixins/stats-aware.ts
+++ b/src/client/mixins/stats-aware.ts
@@ -55,6 +55,25 @@ export class StatsAwareMixin {
     return await this.client._connection.get(fullUrl, options);
   }
 
+  public async getCustomObjectTypes() {
+    if (this.delayInSeconds > 0) {
+      await this.delay(this.delayInSeconds);
+    }
+    return await this.client._connection.get('/v1/customobjects.json');
+  }
+
+  public async getBulkExportCustomObjectJobs(apiName: string) {
+    if (this.delayInSeconds > 0) {
+      await this.delay(this.delayInSeconds);
+    }
+    const baseEndpoint = this.client._connection._options.endpoint.replace('/rest', '');
+    const fullUrl = `${baseEndpoint}/bulk/v1/customobjects/${apiName}/export.json`;
+    const options = {
+      data: { _method: 'GET' },
+    };
+    return await this.client._connection.get(fullUrl, options);
+  }
+
   public async delay(seconds: number) {
     return new Promise(resolve => setTimeout(resolve, seconds * 1000));
   }

--- a/src/client/mixins/stats-aware.ts
+++ b/src/client/mixins/stats-aware.ts
@@ -18,6 +18,43 @@ export class StatsAwareMixin {
     return await this.client._connection.get('/v1/stats/usage/last7days.json');
   }
 
+  public async getBulkExportLeadJobs() {
+    if (this.delayInSeconds > 0) {
+      await this.delay(this.delayInSeconds);
+    }
+    // Get the base endpoint URL (without /rest) and construct full bulk API URL
+    const baseEndpoint = this.client._connection._options.endpoint.replace('/rest', '');
+    const fullUrl = `${baseEndpoint}/bulk/v1/leads/export.json`;
+    const options = {
+      data: { _method: 'GET' },
+    };
+    return await this.client._connection.get(fullUrl, options);
+  }
+
+  public async getBulkExportActivityJobs() {
+    if (this.delayInSeconds > 0) {
+      await this.delay(this.delayInSeconds);
+    }
+    const baseEndpoint = this.client._connection._options.endpoint.replace('/rest', '');
+    const fullUrl = `${baseEndpoint}/bulk/v1/activities/export.json`;
+    const options = {
+      data: { _method: 'GET' },
+    };
+    return await this.client._connection.get(fullUrl, options);
+  }
+
+  public async getBulkExportProgramMemberJobs() {
+    if (this.delayInSeconds > 0) {
+      await this.delay(this.delayInSeconds);
+    }
+    const baseEndpoint = this.client._connection._options.endpoint.replace('/rest', '');
+    const fullUrl = `${baseEndpoint}/bulk/v1/program/members/export.json`;
+    const options = {
+      data: { _method: 'GET' },
+    };
+    return await this.client._connection.get(fullUrl, options);
+  }
+
   public async delay(seconds: number) {
     return new Promise(resolve => setTimeout(resolve, seconds * 1000));
   }

--- a/src/steps/check-bulk-api-usage.ts
+++ b/src/steps/check-bulk-api-usage.ts
@@ -15,6 +15,11 @@ export class CheckBulkApiUsageStep extends BaseStep implements StepInterface {
     type: FieldDefinition.Type.NUMERIC,
     optionality: FieldDefinition.Optionality.OPTIONAL,
     description: 'Your daily bulk export limit in MB (default: 500)',
+  }, {
+    field: 'previousUsageMB',
+    type: FieldDefinition.Type.NUMERIC,
+    optionality: FieldDefinition.Optionality.OPTIONAL,
+    description: 'MB used by previous API users (use {{marketo.bulkExports.bulkApiUsage}} to chain steps across multiple users)',
   }];
   protected expectedRecords: ExpectedRecord[] = [{
     id: 'bulkExports',
@@ -31,6 +36,7 @@ export class CheckBulkApiUsageStep extends BaseStep implements StepInterface {
     const stepData: any = step.getData().toJavaScript();
     const exportLimitMB = stepData.exportLimit || 500;
     const exportLimitBytes = exportLimitMB * 1024 * 1024;
+    const previousUsageBytes = (stepData.previousUsageMB || 0) * 1024 * 1024;
 
     try {
       // Get all export jobs from the different bulk API endpoints
@@ -89,18 +95,36 @@ export class CheckBulkApiUsageStep extends BaseStep implements StepInterface {
         }
       }
 
-      // Convert to MB for display
-      const totalMBUsed = (totalBytesToday / (1024 * 1024)).toFixed(2);
-      const percentUsage = ((totalBytesToday / exportLimitBytes) * 100).toFixed(2);
+      // Convert to MB for display. If previousUsageBytes is set, the combined total is
+      // what gets compared against the limit and output as the token for the next step.
+      const thisUserMBUsed = (totalBytesToday / (1024 * 1024)).toFixed(2);
+      const combinedBytes = totalBytesToday + previousUsageBytes;
+      const combinedMBUsed = (combinedBytes / (1024 * 1024)).toFixed(2);
+      const percentUsage = ((combinedBytes / exportLimitBytes) * 100).toFixed(2);
+      const isAccumulating = previousUsageBytes > 0;
 
-      if (totalBytesToday < (0.9 * exportLimitBytes)) {
-        return this.pass('You have used %s MB of your %d MB daily bulk export limit, which is %s%% of your quota. This is based on %d completed export job(s) today.',
-                         [totalMBUsed, exportLimitMB, percentUsage, jobCount],
-                         [this.keyValue('bulkExports', 'Checked Bulk API Usage', { bulkApiUsage: parseFloat(totalMBUsed) })]);
+      const passMessage = isAccumulating
+        ? 'This user has used %s MB today. Combined with previous users, total usage is %s MB of your %d MB daily limit (%s%%). Based on %d completed export job(s) today.'
+        : 'You have used %s MB of your %d MB daily bulk export limit, which is %s%% of your quota. This is based on %d completed export job(s) today.';
+      const failMessage = isAccumulating
+        ? 'This user has used %s MB today. Combined with previous users, total usage is %s MB of your %d MB daily limit (%s%%). You are approaching or have exceeded your daily limit. Based on %d completed export job(s) today.'
+        : 'You have used %s MB of your %d MB daily bulk export limit, which is %s%% of your quota. This is based on %d completed export job(s) today. You are approaching or have exceeded your daily limit.';
+
+      const passArgs = isAccumulating
+        ? [thisUserMBUsed, combinedMBUsed, exportLimitMB, percentUsage, jobCount]
+        : [combinedMBUsed, exportLimitMB, percentUsage, jobCount];
+      const failArgs = isAccumulating
+        ? [thisUserMBUsed, combinedMBUsed, exportLimitMB, percentUsage, jobCount]
+        : [combinedMBUsed, exportLimitMB, percentUsage, jobCount];
+
+      // Always output the combined total so the next step's {{marketo.bulkExports.bulkApiUsage}}
+      // token carries the running accumulated total across all chained users.
+      const record = this.keyValue('bulkExports', 'Checked Bulk API Usage', { bulkApiUsage: parseFloat(combinedMBUsed) });
+
+      if (combinedBytes < (0.9 * exportLimitBytes)) {
+        return this.pass(passMessage, passArgs, [record]);
       }
-      return this.fail('You have used %s MB of your %d MB daily bulk export limit, which is %s%% of your quota. This is based on %d completed export job(s) today. You are approaching or have exceeded your daily limit.',
-                       [totalMBUsed, exportLimitMB, percentUsage, jobCount],
-                       [this.keyValue('bulkExports', 'Checked Bulk API Usage', { bulkApiUsage: parseFloat(totalMBUsed) })]);
+      return this.fail(failMessage, failArgs, [record]);
     } catch (e) {
       return this.error('There was a problem checking the Bulk API Usage: %s', [e.toString()]);
     }

--- a/src/steps/check-bulk-api-usage.ts
+++ b/src/steps/check-bulk-api-usage.ts
@@ -1,0 +1,95 @@
+/*tslint:disable:no-else-after-return*/
+
+import { BaseStep, Field, StepInterface, ExpectedRecord } from '../core/base-step';
+import { Step, FieldDefinition, StepDefinition, RecordDefinition } from '../proto/cog_pb';
+
+export class CheckBulkApiUsageStep extends BaseStep implements StepInterface {
+
+  protected stepName: string = 'Check daily Marketo Bulk API usage';
+  protected stepExpression: string = 'there should be less than 90% usage of your daily bulk API limit';
+  protected stepType: StepDefinition.Type = StepDefinition.Type.VALIDATION;
+  protected actionList: string[] = ['check'];
+  protected targetObject: string = 'Bulk API Usage';
+  protected expectedFields: Field[] = [{
+    field: 'exportLimit',
+    type: FieldDefinition.Type.NUMERIC,
+    optionality: FieldDefinition.Optionality.OPTIONAL,
+    description: 'Your daily bulk export limit in MB (default: 500)',
+  }];
+  protected expectedRecords: ExpectedRecord[] = [{
+    id: 'bulkExports',
+    type: RecordDefinition.Type.KEYVALUE,
+    fields: [{
+      field: 'bulkApiUsage',
+      type: FieldDefinition.Type.NUMERIC,
+      description: 'Daily Bulk API Usage in MB',
+    }],
+    dynamicFields: false,
+  }];
+
+  async executeStep(step: Step) {
+    const stepData: any = step.getData().toJavaScript();
+    const exportLimitMB = stepData.exportLimit || 500;
+    const exportLimitBytes = exportLimitMB * 1024 * 1024;
+
+    try {
+      // Get all export jobs from the different bulk API endpoints
+      const leadJobsResponse = await this.client.getBulkExportLeadJobs();
+      const activityJobsResponse = await this.client.getBulkExportActivityJobs();
+      const programMemberJobsResponse = await this.client.getBulkExportProgramMemberJobs();
+
+      // Calculate today's total usage by summing fileSize from all completed jobs created today
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+
+      let totalBytesToday = 0;
+      let jobCount = 0;
+
+      // Helper function to process jobs from each endpoint
+      const processJobs = (jobs: any[]) => {
+        if (!jobs || !Array.isArray(jobs)) {
+          return;
+        }
+
+        jobs.forEach((job) => {
+          // Only count jobs created today and that have completed
+          const createdAt = new Date(job.createdAt);
+          createdAt.setHours(0, 0, 0, 0);
+
+          if (createdAt.getTime() === today.getTime() && job.status === 'Completed' && job.fileSize) {
+            totalBytesToday += job.fileSize;
+            jobCount += 1;
+          }
+        });
+      };
+
+      // Process jobs from all endpoints
+      if (leadJobsResponse.result) {
+        processJobs(leadJobsResponse.result);
+      }
+      if (activityJobsResponse.result) {
+        processJobs(activityJobsResponse.result);
+      }
+      if (programMemberJobsResponse.result) {
+        processJobs(programMemberJobsResponse.result);
+      }
+
+      // Convert to MB for display
+      const totalMBUsed = (totalBytesToday / (1024 * 1024)).toFixed(2);
+      const percentUsage = ((totalBytesToday / exportLimitBytes) * 100).toFixed(2);
+
+      if (totalBytesToday < (0.9 * exportLimitBytes)) {
+        return this.pass('You have used %s MB of your %d MB daily bulk export limit, which is %s%% of your quota. This is based on %d completed export job(s) today.',
+                         [totalMBUsed, exportLimitMB, percentUsage, jobCount],
+                         [this.keyValue('bulkExports', 'Checked Bulk API Usage', { bulkApiUsage: parseFloat(totalMBUsed) })]);
+      }
+      return this.fail('You have used %s MB of your %d MB daily bulk export limit, which is %s%% of your quota. This is based on %d completed export job(s) today. You are approaching or have exceeded your daily limit.',
+                       [totalMBUsed, exportLimitMB, percentUsage, jobCount],
+                       [this.keyValue('bulkExports', 'Checked Bulk API Usage', { bulkApiUsage: parseFloat(totalMBUsed) })]);
+    } catch (e) {
+      return this.error('There was a problem checking the Bulk API Usage: %s', [e.toString()]);
+    }
+  }
+}
+
+export { CheckBulkApiUsageStep as Step };

--- a/src/steps/check-bulk-api-usage.ts
+++ b/src/steps/check-bulk-api-usage.ts
@@ -37,10 +37,12 @@ export class CheckBulkApiUsageStep extends BaseStep implements StepInterface {
       const leadJobsResponse = await this.client.getBulkExportLeadJobs();
       const activityJobsResponse = await this.client.getBulkExportActivityJobs();
       const programMemberJobsResponse = await this.client.getBulkExportProgramMemberJobs();
+      const customObjectTypesResponse = await this.client.getCustomObjectTypes();
 
-      // Calculate today's total usage by summing fileSize from all completed jobs created today
-      const today = new Date();
-      today.setHours(0, 0, 0, 0);
+      // Calculate today's total usage by summing fileSize from all completed jobs that
+      // finished today in Central Time. Marketo's daily quota resets at midnight Central
+      // Time, so this must match the timezone Marketo uses — not the server's local time.
+      const todayCentralStr = new Date().toLocaleDateString('en-US', { timeZone: 'America/Chicago' });
 
       let totalBytesToday = 0;
       let jobCount = 0;
@@ -52,11 +54,14 @@ export class CheckBulkApiUsageStep extends BaseStep implements StepInterface {
         }
 
         jobs.forEach((job) => {
-          // Only count jobs created today and that have completed
-          const createdAt = new Date(job.createdAt);
-          createdAt.setHours(0, 0, 0, 0);
-
-          if (createdAt.getTime() === today.getTime() && job.status === 'Completed' && job.fileSize) {
+          // Only count completed jobs whose finishedAt falls on today in Central Time.
+          // Using finishedAt (not createdAt) matches how Marketo attributes quota usage,
+          // and using Central Time matches Marketo's midnight quota reset.
+          if (!job.finishedAt || job.status !== 'Completed' || !job.fileSize) {
+            return;
+          }
+          const jobFinishedCentralStr = new Date(job.finishedAt).toLocaleDateString('en-US', { timeZone: 'America/Chicago' });
+          if (jobFinishedCentralStr === todayCentralStr) {
             totalBytesToday += job.fileSize;
             jobCount += 1;
           }
@@ -72,6 +77,16 @@ export class CheckBulkApiUsageStep extends BaseStep implements StepInterface {
       }
       if (programMemberJobsResponse.result) {
         processJobs(programMemberJobsResponse.result);
+      }
+
+      // Process custom object export jobs for each custom object type
+      if (customObjectTypesResponse && customObjectTypesResponse.result) {
+        for (const customObjectType of customObjectTypesResponse.result) {
+          const customObjectJobsResponse = await this.client.getBulkExportCustomObjectJobs(customObjectType.name);
+          if (customObjectJobsResponse && customObjectJobsResponse.result) {
+            processJobs(customObjectJobsResponse.result);
+          }
+        }
       }
 
       // Convert to MB for display

--- a/src/steps/check-lead-activity-by-id.ts
+++ b/src/steps/check-lead-activity-by-id.ts
@@ -114,6 +114,16 @@ export class CheckLeadActivityByIdStep extends BaseStep implements StepInterface
       }
 
       /* Expected attributes passed to test step. Translate object/map as array for easier comparison with actual attributes */
+      const unresolvedTemplates = Object.entries(withAttributes)
+        .filter(([, v]) => typeof v === 'string' && v.includes('{{') && v.includes('}}'))
+        .map(([k]) => k);
+      if (unresolvedTemplates.length > 0) {
+        return this.error(
+          'One or more withAttributes values could not be resolved from a template variable: %s. ' +
+          'Check that all referenced fields (e.g. {{marketo.lead.lastProgramProcessed}}) are set on the lead before this step runs.',
+          [unresolvedTemplates.join(', ')],
+        );
+      }
       const expectedAttributes = Object.keys(withAttributes).map((key) => { return { name: key, value: withAttributes[key] }; });
       let validatedActivity;
 

--- a/src/steps/check-lead-activity.ts
+++ b/src/steps/check-lead-activity.ts
@@ -136,6 +136,16 @@ export class CheckLeadActivityStep extends BaseStep implements StepInterface {
       activityTypeIdOrName = activityType.id;
 
       /* Expected attributes passed to test step. Translate object/map as array for easier comparison with actual attributes */
+      const unresolvedTemplates = Object.entries(withAttributes)
+        .filter(([, v]) => typeof v === 'string' && v.includes('{{') && v.includes('}}'))
+        .map(([k]) => k);
+      if (unresolvedTemplates.length > 0) {
+        return this.error(
+          'One or more withAttributes values could not be resolved from a template variable: %s. ' +
+          'Check that all referenced fields (e.g. {{marketo.lead.lastProgramProcessed}}) are set on the lead before this step runs.',
+          [unresolvedTemplates.join(', ')],
+        );
+      }
       const expectedAttributes = Object.keys(withAttributes).map((key) => { return { name: key, value: withAttributes[key] }; });
       if ((stepData.multiple_email && Array.isArray(stepData.multiple_email) && stepData.multiple_email.length > 0) ||
           (stepData.multiple_id && Array.isArray(stepData.multiple_id) && stepData.multiple_id.length > 0)) {

--- a/src/steps/lead-update.ts
+++ b/src/steps/lead-update.ts
@@ -6,7 +6,7 @@ import { Step, FieldDefinition, StepDefinition, RecordDefinition, StepRecord } f
 export class UpdateLeadStep extends BaseStep implements StepInterface {
 
   protected stepName: string = 'Update a Marketo lead';
-  protected stepExpression: string = 'update a marketo lead';
+  protected stepExpression: string = 'update an existing marketo lead';
   protected stepType: StepDefinition.Type = StepDefinition.Type.ACTION;
   protected actionList: string[] = ['update'];
   protected targetObject: string = 'Lead';

--- a/src/steps/program-members/program-member-add-or-remove.ts
+++ b/src/steps/program-members/program-member-add-or-remove.ts
@@ -78,7 +78,7 @@ export class AddOrRemoveProgramMemberStep extends BaseStep implements StepInterf
       // If programId is not numeric, assume it's a program name and look up the ID
       if (!numericRegex.test(programId)) {
         const program: any = await this.client.findProgramsByName(programId);
-        if (program.result.length === 0) {
+        if (!program.result || program.result.length === 0) {
           return this.error('Program with name %s does not exist', [
             programId,
           ]);

--- a/src/steps/program-members/program-member-count.ts
+++ b/src/steps/program-members/program-member-count.ts
@@ -38,10 +38,18 @@ export class ProgramMemberCountStep extends BaseStep implements StepInterface {
     const stepData: any = step.getData() ? step.getData().toJavaScript() : {};
     const programName = stepData.programName;
 
+    if (!programName || (typeof programName === 'string' && programName.trim() === '')) {
+      return this.error(
+        'Program name is required but was not provided or could not be resolved. ' +
+        'Check that any template variable (e.g. {{marketo.lead.lastProgramProcessed}}) resolves to a valid program name.',
+        [],
+      );
+    }
+
     try {
       // Check if program exists and also get the id
       const program: any = await this.client.findProgramsByName(programName);
-      if (program.result && program.result.length === 0) {
+      if (!program.result || program.result.length === 0) {
         return this.error('Program with name %s does not exist', [
           programName,
         ]);

--- a/src/steps/program-members/program-member-field-equals.ts
+++ b/src/steps/program-members/program-member-field-equals.ts
@@ -71,6 +71,14 @@ export class ProgramMemberFieldEqualsStep extends BaseStep implements StepInterf
       return this.error("The operator '%s' requires an expected value. Please provide one.", [operator]);
     }
 
+    if (!programName || (typeof programName === 'string' && programName.trim() === '')) {
+      return this.error(
+        'Program name is required but was not provided or could not be resolved. ' +
+        'Check that any template variable (e.g. {{marketo.lead.lastProgramProcessed}}) resolves to a valid program name.',
+        [],
+      );
+    }
+
     try {
       const emailRegex = /(.+)@(.+){2,}\.(.+){2,}/;
       let lookupField = 'id';
@@ -89,7 +97,7 @@ export class ProgramMemberFieldEqualsStep extends BaseStep implements StepInterf
 
       // Check if program exists and also get the id
       const program: any = await this.client.findProgramsByName(programName);
-      if (program.result.length === 0) {
+      if (!program.result || program.result.length === 0) {
         return this.error('Program with name %s does not exist', [
           programName,
         ]);

--- a/test/client/caching-client-wrapper.ts
+++ b/test/client/caching-client-wrapper.ts
@@ -18,6 +18,9 @@ describe('CachingClientWrapper', () => {
     clientWrapperStub = {
       getDailyApiUsage: sinon.spy(),
       getWeeklyApiUsage: sinon.spy(),
+      getBulkExportLeadJobs: sinon.spy(),
+      getBulkExportActivityJobs: sinon.spy(),
+      getBulkExportProgramMemberJobs: sinon.spy(),
       getActivitiesByLeadId: sinon.spy(),
       getActivityPagingToken: sinon.spy(),
       getActivityTypes: sinon.spy(),
@@ -336,6 +339,30 @@ describe('CachingClientWrapper', () => {
     cachingClientWrapperUnderTest.getWeeklyApiUsage();
 
     expect(clientWrapperStub.getWeeklyApiUsage).to.have.been.called;
+    done();
+  });
+
+  it('getBulkExportLeadJobs using original function', (done) => {
+    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap, null);
+    cachingClientWrapperUnderTest.getBulkExportLeadJobs();
+
+    expect(clientWrapperStub.getBulkExportLeadJobs).to.have.been.called;
+    done();
+  });
+
+  it('getBulkExportActivityJobs using original function', (done) => {
+    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap, null);
+    cachingClientWrapperUnderTest.getBulkExportActivityJobs();
+
+    expect(clientWrapperStub.getBulkExportActivityJobs).to.have.been.called;
+    done();
+  });
+
+  it('getBulkExportProgramMemberJobs using original function', (done) => {
+    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap, null);
+    cachingClientWrapperUnderTest.getBulkExportProgramMemberJobs();
+
+    expect(clientWrapperStub.getBulkExportProgramMemberJobs).to.have.been.called;
     done();
   });
 

--- a/test/steps/check-bulk-api-usage.ts
+++ b/test/steps/check-bulk-api-usage.ts
@@ -370,4 +370,75 @@ describe('CheckBulkApiUsageStep', () => {
     const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
     expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
   });
+
+  it('should add previousUsageMB to this user\'s usage when accumulating across multiple users', async () => {
+    const nowISO = new Date().toISOString();
+
+    // This user has 100MB, previous users accumulated 200MB → combined 300MB < 90% of 500MB
+    protoStep.setData(Struct.fromJavaScript({
+      exportLimit: 500,
+      previousUsageMB: 200,
+    }));
+
+    clientWrapperStub.getBulkExportLeadJobs.returns(Promise.resolve({
+      success: true,
+      result: [{ finishedAt: nowISO, status: 'Completed', fileSize: 100 * 1024 * 1024 }],
+    }));
+    clientWrapperStub.getBulkExportActivityJobs.returns(Promise.resolve({ success: true, result: [] }));
+    clientWrapperStub.getBulkExportProgramMemberJobs.returns(Promise.resolve({ success: true, result: [] }));
+    clientWrapperStub.getCustomObjectTypes.returns(Promise.resolve({ success: true, result: [] }));
+
+    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+    // 300MB combined < 450MB (90% of 500MB) — should pass
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+  });
+
+  it('should fail when combined usage with previousUsageMB exceeds 90% of the limit', async () => {
+    const nowISO = new Date().toISOString();
+
+    // This user has 100MB, previous users accumulated 360MB → combined 460MB > 90% of 500MB
+    protoStep.setData(Struct.fromJavaScript({
+      exportLimit: 500,
+      previousUsageMB: 360,
+    }));
+
+    clientWrapperStub.getBulkExportLeadJobs.returns(Promise.resolve({
+      success: true,
+      result: [{ finishedAt: nowISO, status: 'Completed', fileSize: 100 * 1024 * 1024 }],
+    }));
+    clientWrapperStub.getBulkExportActivityJobs.returns(Promise.resolve({ success: true, result: [] }));
+    clientWrapperStub.getBulkExportProgramMemberJobs.returns(Promise.resolve({ success: true, result: [] }));
+    clientWrapperStub.getCustomObjectTypes.returns(Promise.resolve({ success: true, result: [] }));
+
+    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+    // 460MB combined >= 450MB (90% of 500MB) — should fail
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.FAILED);
+  });
+
+  it('should output combined total as bulkApiUsage so the next step can accumulate further', async () => {
+    const nowISO = new Date().toISOString();
+
+    // This user: 100MB. Previous: 150MB. Expected output token: 250MB
+    protoStep.setData(Struct.fromJavaScript({
+      exportLimit: 500,
+      previousUsageMB: 150,
+    }));
+
+    clientWrapperStub.getBulkExportLeadJobs.returns(Promise.resolve({
+      success: true,
+      result: [{ finishedAt: nowISO, status: 'Completed', fileSize: 100 * 1024 * 1024 }],
+    }));
+    clientWrapperStub.getBulkExportActivityJobs.returns(Promise.resolve({ success: true, result: [] }));
+    clientWrapperStub.getBulkExportProgramMemberJobs.returns(Promise.resolve({ success: true, result: [] }));
+    clientWrapperStub.getCustomObjectTypes.returns(Promise.resolve({ success: true, result: [] }));
+
+    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+
+    // The record should carry the combined 250MB so the next step's
+    // {{marketo.bulkExports.bulkApiUsage}} token resolves to 250
+    const record = response.getRecordsList()[0];
+    const recordData = record.getKeyValue().toJavaScript();
+    expect(recordData['bulkApiUsage']).to.equal(250);
+  });
 });

--- a/test/steps/check-bulk-api-usage.ts
+++ b/test/steps/check-bulk-api-usage.ts
@@ -1,0 +1,273 @@
+import { Struct } from 'google-protobuf/google/protobuf/struct_pb';
+import * as chai from 'chai';
+import { default as sinon } from 'ts-sinon';
+import * as sinonChai from 'sinon-chai';
+import 'mocha';
+
+import { Step as ProtoStep, StepDefinition, RunStepResponse } from '../../src/proto/cog_pb';
+import { Step } from '../../src/steps/check-bulk-api-usage';
+
+chai.use(sinonChai);
+
+describe('CheckBulkApiUsageStep', () => {
+  const expect = chai.expect;
+  let protoStep: ProtoStep;
+  let stepUnderTest: Step;
+  let clientWrapperStub: any;
+
+  beforeEach(() => {
+    protoStep = new ProtoStep();
+    clientWrapperStub = sinon.stub();
+    clientWrapperStub.getBulkExportLeadJobs = sinon.stub();
+    clientWrapperStub.getBulkExportActivityJobs = sinon.stub();
+    clientWrapperStub.getBulkExportProgramMemberJobs = sinon.stub();
+    stepUnderTest = new Step(clientWrapperStub);
+  });
+
+  it('should return expected step metadata', () => {
+    const stepDef: StepDefinition = stepUnderTest.getDefinition();
+    expect(stepDef.getStepId()).to.equal('CheckBulkApiUsageStep');
+    expect(stepDef.getName()).to.equal('Check daily Marketo Bulk API usage');
+    expect(stepDef.getExpression()).to.equal('there should be less than 90% usage of your daily bulk API limit');
+    expect(stepDef.getType()).to.equal(StepDefinition.Type.VALIDATION);
+  });
+
+  it('should respond with success if bulk API usage is less than 90% of the daily limit', async () => {
+    const expectedLimit: number = 500; // 500MB default
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    
+    protoStep.setData(Struct.fromJavaScript({
+      exportLimit: expectedLimit,
+    }));
+    
+    // Mock lead export jobs - 100MB used today
+    clientWrapperStub.getBulkExportLeadJobs.returns(Promise.resolve({
+      success: true,
+      result: [
+        {
+          createdAt: today.toISOString(),
+          status: 'Completed',
+          fileSize: 100 * 1024 * 1024, // 100MB
+        },
+      ],
+    }));
+    
+    // Mock activity export jobs - 50MB used today
+    clientWrapperStub.getBulkExportActivityJobs.returns(Promise.resolve({
+      success: true,
+      result: [
+        {
+          createdAt: today.toISOString(),
+          status: 'Completed',
+          fileSize: 50 * 1024 * 1024, // 50MB
+        },
+      ],
+    }));
+    
+    // Mock program member export jobs - empty
+    clientWrapperStub.getBulkExportProgramMemberJobs.returns(Promise.resolve({
+      success: true,
+      result: [],
+    }));
+    
+    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+  });
+
+  it('should respond with a failure if bulk API usage is more than 90% of the daily limit', async () => {
+    const expectedLimit: number = 500;
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    
+    protoStep.setData(Struct.fromJavaScript({
+      exportLimit: expectedLimit,
+    }));
+    
+    // Mock lead export jobs - 400MB used today
+    clientWrapperStub.getBulkExportLeadJobs.returns(Promise.resolve({
+      success: true,
+      result: [
+        {
+          createdAt: today.toISOString(),
+          status: 'Completed',
+          fileSize: 400 * 1024 * 1024, // 400MB
+        },
+      ],
+    }));
+    
+    // Mock activity export jobs - 100MB used today
+    clientWrapperStub.getBulkExportActivityJobs.returns(Promise.resolve({
+      success: true,
+      result: [
+        {
+          createdAt: today.toISOString(),
+          status: 'Completed',
+          fileSize: 100 * 1024 * 1024, // 100MB
+        },
+      ],
+    }));
+    
+    // Mock program member export jobs - empty
+    clientWrapperStub.getBulkExportProgramMemberJobs.returns(Promise.resolve({
+      success: true,
+      result: [],
+    }));
+    
+    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.FAILED);
+  });
+
+  it('should only count jobs from today', async () => {
+    const expectedLimit: number = 500;
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const yesterday = new Date(today);
+    yesterday.setDate(yesterday.getDate() - 1);
+    
+    protoStep.setData(Struct.fromJavaScript({
+      exportLimit: expectedLimit,
+    }));
+    
+    // Mock lead export jobs - one from today (50MB), one from yesterday (400MB)
+    clientWrapperStub.getBulkExportLeadJobs.returns(Promise.resolve({
+      success: true,
+      result: [
+        {
+          createdAt: today.toISOString(),
+          status: 'Completed',
+          fileSize: 50 * 1024 * 1024, // 50MB today
+        },
+        {
+          createdAt: yesterday.toISOString(),
+          status: 'Completed',
+          fileSize: 400 * 1024 * 1024, // 400MB yesterday (should not count)
+        },
+      ],
+    }));
+    
+    clientWrapperStub.getBulkExportActivityJobs.returns(Promise.resolve({
+      success: true,
+      result: [],
+    }));
+    
+    clientWrapperStub.getBulkExportProgramMemberJobs.returns(Promise.resolve({
+      success: true,
+      result: [],
+    }));
+    
+    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+    // Should pass because only 50MB from today counts
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+  });
+
+  it('should only count completed jobs', async () => {
+    const expectedLimit: number = 500;
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    
+    protoStep.setData(Struct.fromJavaScript({
+      exportLimit: expectedLimit,
+    }));
+    
+    // Mock lead export jobs - one completed (50MB), one queued (400MB)
+    clientWrapperStub.getBulkExportLeadJobs.returns(Promise.resolve({
+      success: true,
+      result: [
+        {
+          createdAt: today.toISOString(),
+          status: 'Completed',
+          fileSize: 50 * 1024 * 1024, // 50MB completed
+        },
+        {
+          createdAt: today.toISOString(),
+          status: 'Queued',
+          fileSize: 400 * 1024 * 1024, // 400MB queued (should not count)
+        },
+      ],
+    }));
+    
+    clientWrapperStub.getBulkExportActivityJobs.returns(Promise.resolve({
+      success: true,
+      result: [],
+    }));
+    
+    clientWrapperStub.getBulkExportProgramMemberJobs.returns(Promise.resolve({
+      success: true,
+      result: [],
+    }));
+    
+    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+    // Should pass because only 50MB from completed jobs counts
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+  });
+
+  it('should handle empty results', async () => {
+    const expectedLimit: number = 500;
+    
+    protoStep.setData(Struct.fromJavaScript({
+      exportLimit: expectedLimit,
+    }));
+    
+    clientWrapperStub.getBulkExportLeadJobs.returns(Promise.resolve({
+      success: true,
+      result: [],
+    }));
+    
+    clientWrapperStub.getBulkExportActivityJobs.returns(Promise.resolve({
+      success: true,
+      result: [],
+    }));
+    
+    clientWrapperStub.getBulkExportProgramMemberJobs.returns(Promise.resolve({
+      success: true,
+      result: [],
+    }));
+    
+    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+    // Should pass with 0MB usage
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+  });
+
+  it('should respond with an error if the marketo client throws an error', async () => {
+    clientWrapperStub.getBulkExportLeadJobs.throws('any error');
+    protoStep.setData(Struct.fromJavaScript({
+      exportLimit: 500,
+    }));
+    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
+  });
+
+  it('should use default limit of 500MB when not specified', async () => {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    
+    // Don't set exportLimit, should default to 500MB
+    protoStep.setData(Struct.fromJavaScript({}));
+    
+    clientWrapperStub.getBulkExportLeadJobs.returns(Promise.resolve({
+      success: true,
+      result: [
+        {
+          createdAt: today.toISOString(),
+          status: 'Completed',
+          fileSize: 400 * 1024 * 1024, // 400MB
+        },
+      ],
+    }));
+    
+    clientWrapperStub.getBulkExportActivityJobs.returns(Promise.resolve({
+      success: true,
+      result: [],
+    }));
+    
+    clientWrapperStub.getBulkExportProgramMemberJobs.returns(Promise.resolve({
+      success: true,
+      result: [],
+    }));
+    
+    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+    // Should pass because 400MB < 90% of 500MB (450MB)
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+  });
+});

--- a/test/steps/check-bulk-api-usage.ts
+++ b/test/steps/check-bulk-api-usage.ts
@@ -21,6 +21,8 @@ describe('CheckBulkApiUsageStep', () => {
     clientWrapperStub.getBulkExportLeadJobs = sinon.stub();
     clientWrapperStub.getBulkExportActivityJobs = sinon.stub();
     clientWrapperStub.getBulkExportProgramMemberJobs = sinon.stub();
+    clientWrapperStub.getCustomObjectTypes = sinon.stub();
+    clientWrapperStub.getBulkExportCustomObjectJobs = sinon.stub();
     stepUnderTest = new Step(clientWrapperStub);
   });
 
@@ -34,128 +36,133 @@ describe('CheckBulkApiUsageStep', () => {
 
   it('should respond with success if bulk API usage is less than 90% of the daily limit', async () => {
     const expectedLimit: number = 500; // 500MB default
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-    
+    // Use current moment — always "today" in any timezone
+    const nowISO = new Date().toISOString();
+
     protoStep.setData(Struct.fromJavaScript({
       exportLimit: expectedLimit,
     }));
-    
+
     // Mock lead export jobs - 100MB used today
     clientWrapperStub.getBulkExportLeadJobs.returns(Promise.resolve({
       success: true,
       result: [
         {
-          createdAt: today.toISOString(),
+          finishedAt: nowISO,
           status: 'Completed',
           fileSize: 100 * 1024 * 1024, // 100MB
         },
       ],
     }));
-    
+
     // Mock activity export jobs - 50MB used today
     clientWrapperStub.getBulkExportActivityJobs.returns(Promise.resolve({
       success: true,
       result: [
         {
-          createdAt: today.toISOString(),
+          finishedAt: nowISO,
           status: 'Completed',
           fileSize: 50 * 1024 * 1024, // 50MB
         },
       ],
     }));
-    
+
     // Mock program member export jobs - empty
     clientWrapperStub.getBulkExportProgramMemberJobs.returns(Promise.resolve({
       success: true,
       result: [],
     }));
-    
+
+    clientWrapperStub.getCustomObjectTypes.returns(Promise.resolve({ success: true, result: [] }));
+
     const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
     expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
   });
 
   it('should respond with a failure if bulk API usage is more than 90% of the daily limit', async () => {
     const expectedLimit: number = 500;
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-    
+    const nowISO = new Date().toISOString();
+
     protoStep.setData(Struct.fromJavaScript({
       exportLimit: expectedLimit,
     }));
-    
+
     // Mock lead export jobs - 400MB used today
     clientWrapperStub.getBulkExportLeadJobs.returns(Promise.resolve({
       success: true,
       result: [
         {
-          createdAt: today.toISOString(),
+          finishedAt: nowISO,
           status: 'Completed',
           fileSize: 400 * 1024 * 1024, // 400MB
         },
       ],
     }));
-    
+
     // Mock activity export jobs - 100MB used today
     clientWrapperStub.getBulkExportActivityJobs.returns(Promise.resolve({
       success: true,
       result: [
         {
-          createdAt: today.toISOString(),
+          finishedAt: nowISO,
           status: 'Completed',
           fileSize: 100 * 1024 * 1024, // 100MB
         },
       ],
     }));
-    
+
     // Mock program member export jobs - empty
     clientWrapperStub.getBulkExportProgramMemberJobs.returns(Promise.resolve({
       success: true,
       result: [],
     }));
-    
+
+    clientWrapperStub.getCustomObjectTypes.returns(Promise.resolve({ success: true, result: [] }));
+
     const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
     expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.FAILED);
   });
 
   it('should only count jobs from today', async () => {
     const expectedLimit: number = 500;
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-    const yesterday = new Date(today);
-    yesterday.setDate(yesterday.getDate() - 1);
-    
+    // Current moment is always "today" in any timezone
+    const nowISO = new Date().toISOString();
+    // 48 hours ago is always "before today" in any timezone
+    const twoDaysAgoISO = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString();
+
     protoStep.setData(Struct.fromJavaScript({
       exportLimit: expectedLimit,
     }));
-    
-    // Mock lead export jobs - one from today (50MB), one from yesterday (400MB)
+
+    // Mock lead export jobs - one from today (50MB), one from two days ago (400MB)
     clientWrapperStub.getBulkExportLeadJobs.returns(Promise.resolve({
       success: true,
       result: [
         {
-          createdAt: today.toISOString(),
+          finishedAt: nowISO,
           status: 'Completed',
           fileSize: 50 * 1024 * 1024, // 50MB today
         },
         {
-          createdAt: yesterday.toISOString(),
+          finishedAt: twoDaysAgoISO,
           status: 'Completed',
-          fileSize: 400 * 1024 * 1024, // 400MB yesterday (should not count)
+          fileSize: 400 * 1024 * 1024, // 400MB two days ago (should not count)
         },
       ],
     }));
-    
+
     clientWrapperStub.getBulkExportActivityJobs.returns(Promise.resolve({
       success: true,
       result: [],
     }));
-    
+
     clientWrapperStub.getBulkExportProgramMemberJobs.returns(Promise.resolve({
       success: true,
       result: [],
     }));
-    
+
+    clientWrapperStub.getCustomObjectTypes.returns(Promise.resolve({ success: true, result: [] }));
+
     const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
     // Should pass because only 50MB from today counts
     expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
@@ -163,26 +170,24 @@ describe('CheckBulkApiUsageStep', () => {
 
   it('should only count completed jobs', async () => {
     const expectedLimit: number = 500;
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-    
+    const nowISO = new Date().toISOString();
+
     protoStep.setData(Struct.fromJavaScript({
       exportLimit: expectedLimit,
     }));
-    
-    // Mock lead export jobs - one completed (50MB), one queued (400MB)
+
+    // Mock lead export jobs - one completed (50MB), one queued (400MB, no finishedAt yet)
     clientWrapperStub.getBulkExportLeadJobs.returns(Promise.resolve({
       success: true,
       result: [
         {
-          createdAt: today.toISOString(),
+          finishedAt: nowISO,
           status: 'Completed',
           fileSize: 50 * 1024 * 1024, // 50MB completed
         },
         {
-          createdAt: today.toISOString(),
           status: 'Queued',
-          fileSize: 400 * 1024 * 1024, // 400MB queued (should not count)
+          fileSize: 400 * 1024 * 1024, // 400MB queued (should not count — no finishedAt)
         },
       ],
     }));
@@ -191,12 +196,14 @@ describe('CheckBulkApiUsageStep', () => {
       success: true,
       result: [],
     }));
-    
+
     clientWrapperStub.getBulkExportProgramMemberJobs.returns(Promise.resolve({
       success: true,
       result: [],
     }));
-    
+
+    clientWrapperStub.getCustomObjectTypes.returns(Promise.resolve({ success: true, result: [] }));
+
     const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
     // Should pass because only 50MB from completed jobs counts
     expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
@@ -218,12 +225,14 @@ describe('CheckBulkApiUsageStep', () => {
       success: true,
       result: [],
     }));
-    
+
     clientWrapperStub.getBulkExportProgramMemberJobs.returns(Promise.resolve({
       success: true,
       result: [],
     }));
-    
+
+    clientWrapperStub.getCustomObjectTypes.returns(Promise.resolve({ success: true, result: [] }));
+
     const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
     // Should pass with 0MB usage
     expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
@@ -239,17 +248,16 @@ describe('CheckBulkApiUsageStep', () => {
   });
 
   it('should use default limit of 500MB when not specified', async () => {
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-    
+    const nowISO = new Date().toISOString();
+
     // Don't set exportLimit, should default to 500MB
     protoStep.setData(Struct.fromJavaScript({}));
-    
+
     clientWrapperStub.getBulkExportLeadJobs.returns(Promise.resolve({
       success: true,
       result: [
         {
-          createdAt: today.toISOString(),
+          finishedAt: nowISO,
           status: 'Completed',
           fileSize: 400 * 1024 * 1024, // 400MB
         },
@@ -260,14 +268,106 @@ describe('CheckBulkApiUsageStep', () => {
       success: true,
       result: [],
     }));
-    
+
     clientWrapperStub.getBulkExportProgramMemberJobs.returns(Promise.resolve({
       success: true,
       result: [],
     }));
-    
+
+    clientWrapperStub.getCustomObjectTypes.returns(Promise.resolve({ success: true, result: [] }));
+
     const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
     // Should pass because 400MB < 90% of 500MB (450MB)
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+  });
+
+  it('should include custom object export jobs in usage calculation', async () => {
+    const expectedLimit: number = 500;
+    const nowISO = new Date().toISOString();
+
+    protoStep.setData(Struct.fromJavaScript({
+      exportLimit: expectedLimit,
+    }));
+
+    clientWrapperStub.getBulkExportLeadJobs.returns(Promise.resolve({ success: true, result: [] }));
+    clientWrapperStub.getBulkExportActivityJobs.returns(Promise.resolve({ success: true, result: [] }));
+    clientWrapperStub.getBulkExportProgramMemberJobs.returns(Promise.resolve({ success: true, result: [] }));
+
+    // Two custom object types
+    clientWrapperStub.getCustomObjectTypes.returns(Promise.resolve({
+      success: true,
+      result: [
+        { name: 'cars_c' },
+        { name: 'orders_c' },
+      ],
+    }));
+
+    // cars_c: 200MB completed today
+    // orders_c: 250MB completed today — total 450MB = 90% of 500MB limit, should fail
+    clientWrapperStub.getBulkExportCustomObjectJobs.withArgs('cars_c').returns(Promise.resolve({
+      success: true,
+      result: [
+        {
+          finishedAt: nowISO,
+          status: 'Completed',
+          fileSize: 200 * 1024 * 1024,
+        },
+      ],
+    }));
+    clientWrapperStub.getBulkExportCustomObjectJobs.withArgs('orders_c').returns(Promise.resolve({
+      success: true,
+      result: [
+        {
+          finishedAt: nowISO,
+          status: 'Completed',
+          fileSize: 250 * 1024 * 1024,
+        },
+      ],
+    }));
+
+    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+    // 450MB >= 90% of 500MB (450MB), should fail
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.FAILED);
+  });
+
+  it('should not count jobs whose finishedAt is before midnight Central Time', async () => {
+    // Marketo resets at midnight Central Time. A job that finished at e.g. 1am UTC is
+    // still the previous calendar day in Central Time (UTC-5/UTC-6) and must not count.
+    // 48 hours ago is unambiguously a previous day in any timezone.
+    const twoDaysAgoISO = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString();
+
+    protoStep.setData(Struct.fromJavaScript({ exportLimit: 500 }));
+
+    clientWrapperStub.getBulkExportLeadJobs.returns(Promise.resolve({
+      success: true,
+      result: [
+        {
+          finishedAt: twoDaysAgoISO,
+          status: 'Completed',
+          fileSize: 460 * 1024 * 1024, // 460MB — would fail if counted, but should not be
+        },
+      ],
+    }));
+    clientWrapperStub.getBulkExportActivityJobs.returns(Promise.resolve({ success: true, result: [] }));
+    clientWrapperStub.getBulkExportProgramMemberJobs.returns(Promise.resolve({ success: true, result: [] }));
+    clientWrapperStub.getCustomObjectTypes.returns(Promise.resolve({ success: true, result: [] }));
+
+    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+    // Should pass — the large job is from a previous day and must not count
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+  });
+
+  it('should gracefully handle getCustomObjectTypes returning no result', async () => {
+    protoStep.setData(Struct.fromJavaScript({ exportLimit: 500 }));
+
+    clientWrapperStub.getBulkExportLeadJobs.returns(Promise.resolve({ success: true, result: [] }));
+    clientWrapperStub.getBulkExportActivityJobs.returns(Promise.resolve({ success: true, result: [] }));
+    clientWrapperStub.getBulkExportProgramMemberJobs.returns(Promise.resolve({ success: true, result: [] }));
+
+    // Simulate API returning success:false with no result (e.g. no custom objects configured)
+    clientWrapperStub.getCustomObjectTypes.returns(Promise.resolve({ success: false }));
+
+    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
     expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
   });
 });

--- a/test/steps/lead-update.ts
+++ b/test/steps/lead-update.ts
@@ -28,7 +28,7 @@ describe('UpdateLeadStep', () => {
     const stepDef: StepDefinition = stepUnderTest.getDefinition();
     expect(stepDef.getStepId()).to.equal('UpdateLeadStep');
     expect(stepDef.getName()).to.equal('Update a Marketo lead');
-    expect(stepDef.getExpression()).to.equal('update a marketo lead');
+    expect(stepDef.getExpression()).to.equal('update an existing marketo lead');
     expect(stepDef.getType()).to.equal(StepDefinition.Type.ACTION);
   });
 


### PR DESCRIPTION
- Add optional previousUsageMB field to CheckBulkApiUsageStep, enabling bulk API quota checks to be chained across multiple Marketo API users
- When previousUsageMB is set, the step adds it to the current user's usage and compares the combined total against the export limit — the output bulkApiUsage record always carries the running accumulated total
- Works with the existing token system: set previousUsageMB = {{marketo.bulkExports.bulkApiUsage}} on steps 2 and 3 to automatically pass the running total down the chain with no changes required to cog-mechanism
- Add 3 new unit tests covering accumulation pass, accumulation fail, and correct token output of the combined total